### PR TITLE
SECURITY-571: harden MavenProxy, archive uploads and JSP output

### DIFF
--- a/src/main/java/org/jahia/modules/forge/actions/ActionSecurityUtils.java
+++ b/src/main/java/org/jahia/modules/forge/actions/ActionSecurityUtils.java
@@ -1,0 +1,68 @@
+/*
+ * ==========================================================================================
+ * =                            JAHIA'S ENTERPRISE DISTRIBUTION                             =
+ * ==========================================================================================
+ *
+ *                                  http://www.jahia.com
+ *
+ * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
+ * ==========================================================================================
+ *
+ *     Copyright (C) 2002-2026 Jahia Solutions Group. All rights reserved.
+ *
+ *     This file is part of a Jahia's Enterprise Distribution.
+ *
+ *     Jahia's Enterprise Distributions must be used in accordance with the terms
+ *     contained in the Jahia Solutions Group Terms & Conditions as well as
+ *     the Jahia Sustainable Enterprise License (JSEL).
+ *
+ *     For questions regarding licensing, support, production usage...
+ *     please contact our team at sales@jahia.com or go to http://www.jahia.com/license.
+ *
+ * ==========================================================================================
+ */
+package org.jahia.modules.forge.actions;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Small security helpers shared by upload/redirect actions: site-relative redirect validation
+ * and log-input sanitization (CR/LF stripping) to prevent log forging.
+ */
+final class ActionSecurityUtils {
+
+    private ActionSecurityUtils() {
+        // utility class - prevent instantiation
+    }
+
+    /**
+     * Only allow site-relative redirect targets. Rejects absolute URLs, protocol-relative URLs
+     * and pseudo-schemes (javascript:, data:, ...) to prevent open redirect / XSS.
+     */
+    static boolean isSafeRedirect(String url) {
+        if (StringUtils.isBlank(url)) {
+            return false;
+        }
+        String lower = url.trim().toLowerCase();
+        return lower.startsWith("/")
+                && !lower.startsWith("//")
+                && !lower.startsWith("/\\")
+                && !lower.contains("://");
+    }
+
+    /**
+     * Sanitize a string before logging by stripping CR/LF and other control characters that could
+     * be used to forge a log line. Returns "null" for null input. Truncated to 200 chars to keep
+     * log lines bounded.
+     */
+    static String sanitizeForLog(String input) {
+        if (input == null) {
+            return "null";
+        }
+        String stripped = input.replaceAll("[\\r\\n\\t\\f\\u0000-\\u001F\\u007F]", "_");
+        if (stripped.length() > 200) {
+            stripped = stripped.substring(0, 200) + "...";
+        }
+        return stripped;
+    }
+}

--- a/src/main/java/org/jahia/modules/forge/actions/ActionSecurityUtils.java
+++ b/src/main/java/org/jahia/modules/forge/actions/ActionSecurityUtils.java
@@ -59,7 +59,7 @@ final class ActionSecurityUtils {
         if (input == null) {
             return "null";
         }
-        String stripped = input.replaceAll("[\\r\\n\\t\\f\\u0000-\\u001F\\u007F]", "_");
+        String stripped = input.replaceAll("[\\u0000-\\u001F\\u007F]", "_");
         if (stripped.length() > 200) {
             stripped = stripped.substring(0, 200) + "...";
         }

--- a/src/main/java/org/jahia/modules/forge/actions/AddVideo.java
+++ b/src/main/java/org/jahia/modules/forge/actions/AddVideo.java
@@ -46,7 +46,8 @@ import java.util.Map;
  */
 public class AddVideo extends Action {
 
-    private transient static Logger logger = org.slf4j.LoggerFactory.getLogger(AddVideo.class);
+    private static final Logger logger = org.slf4j.LoggerFactory.getLogger(AddVideo.class);
+    private static final String ALLOWFULLSCREEN = "allowfullscreen";
 
     @Override
     public ActionResult doExecute(HttpServletRequest req, RenderContext renderContext, Resource resource,
@@ -60,12 +61,12 @@ public class AddVideo extends Action {
         session.checkout(module);
 
         JCRNodeWrapper videoNode = createNode(req, parameters, module, "jnt:videostreaming", "video", false);
-        String allowfullscreen = getParameter(parameters, "allowfullscreen");
+        String allowfullscreen = getParameter(parameters, ALLOWFULLSCREEN);
 
         if (allowfullscreen != null && allowfullscreen.equals("on")) {
-            videoNode.setProperty("allowfullscreen", true);
+            videoNode.setProperty(ALLOWFULLSCREEN, true);
         } else {
-            videoNode.setProperty("allowfullscreen", false);
+            videoNode.setProperty(ALLOWFULLSCREEN, false);
         }
         videoNode.setProperty("html5Player", true);
 

--- a/src/main/java/org/jahia/modules/forge/actions/CalculateCompletion.java
+++ b/src/main/java/org/jahia/modules/forge/actions/CalculateCompletion.java
@@ -43,7 +43,11 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Date: 2013-05-09
@@ -53,7 +57,7 @@ import java.util.*;
  */
 public class CalculateCompletion extends Action {
 
-    private transient static Logger logger = org.slf4j.LoggerFactory.getLogger(CalculateCompletion.class);
+    private static final Logger logger = org.slf4j.LoggerFactory.getLogger(CalculateCompletion.class);
 
     private static final int TEXT = 100;
     private static final int WEAKREFERENCE = 200;
@@ -63,17 +67,21 @@ public class CalculateCompletion extends Action {
     private static final int TAGS = 600;
     private static final int SKIP = 900;
 
-    private static boolean canBePublished = true;
-    private static int completion = 0, index = 0;
-    private static Map<Integer, Map<String, Object>> todoList = new LinkedHashMap<Integer, Map<String, Object>>();
-    private static List<Object[]> mandatoryProperties, otherProperties;
+    private static final String RESOURCES = "resources.privateappstore";
 
-    private static void initMandatoryProperties(JCRNodeWrapper module) throws RepositoryException {
+    private boolean canBePublished = true;
+    private int completion = 0;
+    private int index = 0;
+    private final Map<Integer, Map<String, Object>> todoList = new LinkedHashMap<>();
+    private List<Object[]> mandatoryProperties;
+    private List<Object[]> otherProperties;
 
-        if (mandatoryProperties == null)
-            mandatoryProperties = new ArrayList<Object[]>();
-        else
+    private void initMandatoryProperties() {
+        if (mandatoryProperties == null) {
+            mandatoryProperties = new ArrayList<>();
+        } else {
             mandatoryProperties.clear();
+        }
 
         mandatoryProperties.add(new Object[]{"jcr:title", TEXT, 20});
         mandatoryProperties.add(new Object[]{"description", TEXT, 20});
@@ -81,9 +89,8 @@ public class CalculateCompletion extends Action {
         mandatoryProperties.add(new Object[]{"versions", VERSIONS, 10});
     }
 
-    private static void initOtherProperties(JCRNodeWrapper module) throws RepositoryException {
-
-        otherProperties = new ArrayList<Object[]>();
+    private void initOtherProperties() {
+        otherProperties = new ArrayList<>();
 
         otherProperties.add(new Object[]{"howToInstall", TEXT, 5});
         otherProperties.add(new Object[]{"authorURL", TEXT, 5});
@@ -93,15 +100,6 @@ public class CalculateCompletion extends Action {
         otherProperties.add(new Object[]{"FAQ", TEXT, 5});
         otherProperties.add(new Object[]{"license", TEXT, 5});
         otherProperties.add(new Object[]{"j:tagList", TAGS, 5});
-//        int authorEmailType;
-//        if (module.hasProperty("authorNameDisplayedAs") && module.getPropertyAsString("authorNameDisplayedAs").equals("organisation")
-//                || (module.getSession().getUser().getProperty("j:email") != null && module.getSession().getUser().getProperty("j:email").isEmpty())) {
-//            authorEmailType = TEXT;
-//        }
-//        else {
-//            authorEmailType = SKIP;
-//        }
-//        otherProperties.add(new Object[]{"authorEmail", authorEmailType, 5});
     }
 
     @Override
@@ -115,15 +113,16 @@ public class CalculateCompletion extends Action {
 
         JCRNodeWrapper module = resource.getNode();
 
-        initMandatoryProperties(module);
-        if (otherProperties == null)
-            initOtherProperties(module);
+        initMandatoryProperties();
+        if (otherProperties == null) {
+            initOtherProperties();
+        }
 
         for (Object[] property : mandatoryProperties) {
-            checkProperty((String) property[0], (Integer) property[1], (Integer) property[2], true, session, module);
+            checkProperty((String) property[0], (Integer) property[1], (Integer) property[2], true, session, module, false);
         }
         for (Object[] property : otherProperties) {
-            checkProperty((String) property[0], (Integer) property[1], (Integer) property[2], false, session, module);
+            checkProperty((String) property[0], (Integer) property[1], (Integer) property[2], false, session, module, false);
         }
 
         JSONObject data = new JSONObject();
@@ -135,120 +134,124 @@ public class CalculateCompletion extends Action {
     }
 
     public static boolean isPublishable(JCRNodeWrapper module) throws RepositoryException {
+        return new CalculateCompletion().computePublishable(module);
+    }
 
+    private boolean computePublishable(JCRNodeWrapper module) throws RepositoryException {
         canBePublished = true;
         JCRSessionWrapper session = module.getSession();
-        initMandatoryProperties(module);
+        initMandatoryProperties();
 
         for (Object[] property : mandatoryProperties) {
             checkProperty((String) property[0], (Integer) property[1], (Integer) property[2], true, session, module, true);
-            if (!canBePublished)
-                return canBePublished;
+            if (!canBePublished) {
+                return false;
+            }
         }
-
         return canBePublished;
     }
 
     private void checkProperty(String name, int type, int percentage, boolean mandatory,
-                               JCRSessionWrapper session, JCRNodeWrapper module) {
-        checkProperty(name, type, percentage, mandatory, session, module, false);
-    }
-
-    private static void checkProperty(String name, int type, int percentage, boolean mandatory,
-                                      JCRSessionWrapper session, JCRNodeWrapper module, boolean simpleCheck) {
-
-        boolean completed = true;
-
-        switch (type) {
-
-            case TEXT:
-                String propertyAsString = module.getPropertyAsString(name);
-                if (propertyAsString == null || isEmptyHtmlText(propertyAsString))
-                    completed = false;
-                break;
-
-            case NODE:
-
-                try {
-                    module.getNode(name);
-                } catch (PathNotFoundException e) {
-                    completed = false;
-                } catch (Exception e) {
-                    logger.warn(e.getMessage(), e);
-                }
-                break;
-
-            case WEAKREFERENCE:
-
-                try {
-                    if (module.getProperty(name).isMultiple()) {
-                        for (Value uuid : module.getProperty(name).getValues()) {
-                            session.getNodeByUUID(uuid.getString());
-                        }
-                    } else {
-                        session.getNodeByUUID(module.getProperty(name).getString());
-                    }
-                } catch (ItemNotFoundException e) {
-                    completed = false;
-                } catch (PathNotFoundException e) {
-                    completed = false;
-                } catch (Exception e) {
-                    logger.warn(e.getMessage(), e);
-                }
-                break;
-
-            case SCREENSHOTS:
-
-                try {
-                    JCRNodeWrapper screenshotsList = module.getNode(name);
-                    if (!JCRTagUtils.hasChildrenOfType(screenshotsList, "jnt:file"))
-                        completed = false;
-                } catch (PathNotFoundException e) {
-                    completed = false;
-                } catch (Exception e) {
-                    logger.warn(e.getMessage(), e);
-                }
-                break;
-
-            case TAGS:
-
-                try {
-                    if (module.getProperty(name).getValues().length == 0)
-                        completed = false;
-                } catch (PathNotFoundException e) {
-                    completed = false;
-                } catch (Exception e) {
-                    logger.warn(e.getMessage(), e);
-                }
-                break;
-
-            case SKIP:
-                break;
-        }
+                               JCRSessionWrapper session, JCRNodeWrapper module, boolean simpleCheck) {
+        boolean completed = isPropertyCompleted(name, type, session, module);
 
         if (completed) {
-            if (simpleCheck)
+            if (simpleCheck) {
                 return;
-            completion += percentage;
-        } else {
-            if (mandatory) {
-                canBePublished = false;
-                if (simpleCheck)
-                    return;
             }
-
-            Map<String, Object> propertyMap = new HashMap<String, Object>();
-            propertyMap.put("name",
-                    Messages.get("resources.privateappstore", "jnt_forgeModule." + name.replace(':', '_'), session.getLocale(), name));
-            propertyMap.put("mandatory", mandatory);
-
-            todoList.put(index++, propertyMap);
+            completion += percentage;
+            return;
         }
 
+        if (mandatory) {
+            canBePublished = false;
+            if (simpleCheck) {
+                return;
+            }
+        }
+
+        Map<String, Object> propertyMap = new HashMap<>();
+        propertyMap.put("name",
+                Messages.get(RESOURCES, "jnt_forgeModule." + name.replace(':', '_'), session.getLocale(), name));
+        propertyMap.put("mandatory", mandatory);
+
+        todoList.put(index++, propertyMap);
+    }
+
+    private static boolean isPropertyCompleted(String name, int type, JCRSessionWrapper session, JCRNodeWrapper module) {
+        switch (type) {
+            case TEXT:
+                String propertyAsString = module.getPropertyAsString(name);
+                return propertyAsString != null && !isEmptyHtmlText(propertyAsString);
+            case NODE:
+                return checkNode(module, name);
+            case WEAKREFERENCE:
+                return checkWeakReference(module, name, session);
+            case SCREENSHOTS:
+                return checkScreenshots(module, name);
+            case TAGS:
+                return checkTags(module, name);
+            case SKIP:
+                return true;
+            default:
+                return true;
+        }
+    }
+
+    private static boolean checkNode(JCRNodeWrapper module, String name) {
+        try {
+            module.getNode(name);
+            return true;
+        } catch (PathNotFoundException e) {
+            return false;
+        } catch (RepositoryException e) {
+            logger.warn(e.getMessage(), e);
+            return true;
+        }
+    }
+
+    private static boolean checkWeakReference(JCRNodeWrapper module, String name, JCRSessionWrapper session) {
+        try {
+            if (module.getProperty(name).isMultiple()) {
+                for (Value uuid : module.getProperty(name).getValues()) {
+                    session.getNodeByUUID(uuid.getString());
+                }
+            } else {
+                session.getNodeByUUID(module.getProperty(name).getString());
+            }
+            return true;
+        } catch (ItemNotFoundException | PathNotFoundException e) {
+            return false;
+        } catch (RepositoryException e) {
+            logger.warn(e.getMessage(), e);
+            return true;
+        }
+    }
+
+    private static boolean checkScreenshots(JCRNodeWrapper module, String name) {
+        try {
+            JCRNodeWrapper screenshotsList = module.getNode(name);
+            return JCRTagUtils.hasChildrenOfType(screenshotsList, "jnt:file");
+        } catch (PathNotFoundException e) {
+            return false;
+        } catch (RepositoryException e) {
+            logger.warn(e.getMessage(), e);
+            return true;
+        }
+    }
+
+    private static boolean checkTags(JCRNodeWrapper module, String name) {
+        try {
+            return module.getProperty(name).getValues().length != 0;
+        } catch (PathNotFoundException e) {
+            return false;
+        } catch (RepositoryException e) {
+            logger.warn(e.getMessage(), e);
+            return true;
+        }
     }
 
     private static boolean isEmptyHtmlText(String html) {
-
         Source source = new Source(html);
         TextExtractor textExtractor = source.getTextExtractor();
 
@@ -258,5 +261,4 @@ public class CalculateCompletion extends Action {
 
         return textExtractor.toString().trim().length() == 0;
     }
-
 }

--- a/src/main/java/org/jahia/modules/forge/actions/CreateEntryFromJar.java
+++ b/src/main/java/org/jahia/modules/forge/actions/CreateEntryFromJar.java
@@ -26,6 +26,7 @@ package org.jahia.modules.forge.actions;
 import org.apache.commons.fileupload.disk.DiskFileItem;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.model.Model;
 import org.apache.xerces.impl.dv.util.Base64;
@@ -92,6 +93,10 @@ public class CreateEntryFromJar extends Action {
     private static final String OWNER = "owner";
     private static final String MODULES_LIST = "modulesList";
     private static final String RESOURCES_PRIVATEAPPSTORE = "resources.privateappstore";
+    /** Maximum accepted size for an uploaded artifact (guards against resource-exhaustion uploads). */
+    private static final long MAX_UPLOAD_SIZE_BYTES = 200L * 1024 * 1024;
+    /** Maximum size of a single tar entry we read into memory (guards against decompression bombs). */
+    private static final long MAX_TAR_ENTRY_SIZE_BYTES = 10L * 1024 * 1024;
 
     String mavenExecutable;
 
@@ -100,6 +105,16 @@ public class CreateEntryFromJar extends Action {
         final FileUpload fu = (FileUpload) request.getAttribute(FileUpload.FILEUPLOAD_ATTRIBUTE);
 
         DiskFileItem uploadedFile = fu.getFileItems().get("file");
+        if (uploadedFile == null) {
+            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.unable.read.file", session.getLocale());
+            return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
+        }
+        if (uploadedFile.getSize() > MAX_UPLOAD_SIZE_BYTES) {
+            logger.warn("CreateEntryFromJar: rejected oversized upload '{}' ({} bytes)", uploadedFile.getName(), uploadedFile.getSize());
+            uploadedFile.delete();
+            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.unable.read.file", session.getLocale());
+            return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
+        }
         String filename = uploadedFile.getName();
         Map<String, List<String>> formParameters = fu.getParameterMap();
         if (!StringUtils.contains(filename, "SNAPSHOT.")) {
@@ -114,6 +129,11 @@ public class CreateEntryFromJar extends Action {
                     TarArchiveEntry entry;
                     while ((entry = tarInputStream.getNextTarEntry()) != null) {
                         if (entry.isFile() && entry.getName().equals("package/package.json")) {
+                            if (entry.getSize() > MAX_TAR_ENTRY_SIZE_BYTES) {
+                                logger.warn("CreateEntryFromJar: package.json entry too large ({} bytes) - rejected", entry.getSize());
+                                String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.unable.read.file", session.getLocale());
+                                return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
+                            }
                             final JSONObject jsonObject = new JSONObject(IOUtils.toString(tarInputStream, "UTF-8"));
                             return createJavascriptModule(uploadedFile, jsonObject, request, renderContext, resource, session, extension, formParameters);
                         }
@@ -274,7 +294,12 @@ public class CreateEntryFromJar extends Action {
         final ActionResult uploadResult = new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put("successRedirectUrl", moduleUrl).put(
                 "successRedirectAbsoluteUrl", moduleAbsoluteUrl));
         if (formParams.containsKey(REDIRECT_URL)) {
-            uploadResult.setUrl(formParams.get(REDIRECT_URL).get(0));
+            String redirectUrl = formParams.get(REDIRECT_URL).get(0);
+            if (isSafeRedirect(redirectUrl)) {
+                uploadResult.setUrl(redirectUrl);
+            } else {
+                logger.warn("CreateEntryFromJar: rejected unsafe redirectURL '{}'", redirectUrl);
+            }
         }
 
         return uploadResult;
@@ -409,7 +434,12 @@ public class CreateEntryFromJar extends Action {
         ActionResult uploadResult = new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put("successRedirectUrl", packageUrl).put(
                 "successRedirectAbsoluteUrl", packageAbsoluteUrl));
         if (formParams.containsKey(REDIRECT_URL)) {
-            uploadResult.setUrl(formParams.get(REDIRECT_URL).get(0));
+            String redirectUrl = formParams.get(REDIRECT_URL).get(0);
+            if (isSafeRedirect(redirectUrl)) {
+                uploadResult.setUrl(redirectUrl);
+            } else {
+                logger.warn("CreateEntryFromJar: rejected unsafe redirectURL '{}'", redirectUrl);
+            }
         }
 
         return uploadResult;
@@ -560,10 +590,30 @@ public class CreateEntryFromJar extends Action {
         ActionResult uploadResult = new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put("successRedirectUrl", moduleUrl).put(
                 "successRedirectAbsoluteUrl", moduleAbsoluteUrl));
         if (formParams.containsKey(REDIRECT_URL)) {
-            uploadResult.setUrl(formParams.get(REDIRECT_URL).get(0));
+            String redirectUrl = formParams.get(REDIRECT_URL).get(0);
+            if (isSafeRedirect(redirectUrl)) {
+                uploadResult.setUrl(redirectUrl);
+            } else {
+                logger.warn("CreateEntryFromJar: rejected unsafe redirectURL '{}'", redirectUrl);
+            }
         }
 
         return uploadResult;
+    }
+
+    /**
+     * Only allow site-relative redirect targets. Rejects absolute URLs, protocol-relative URLs
+     * and pseudo-schemes (javascript:, data:, ...) to prevent open redirect / XSS after upload.
+     */
+    private static boolean isSafeRedirect(String url) {
+        if (StringUtils.isBlank(url)) {
+            return false;
+        }
+        String lower = url.trim().toLowerCase();
+        return lower.startsWith("/")
+                && !lower.startsWith("//")
+                && !lower.startsWith("/\\")
+                && !lower.contains("://");
     }
 
     public void setMavenExecutable(String mavenExecutable) {
@@ -620,10 +670,12 @@ public class CreateEntryFromJar extends Action {
             if (!StringUtils.isEmpty(releaseInfo.getUsername()) && !StringUtils.isEmpty(releaseInfo.getPassword())) {
                 settings = File.createTempFile("settings", ".xml");
                 try (BufferedWriter w = new BufferedWriter(new FileWriter(settings))) {
-                    w.write("<settings><servers><server><id>" + releaseInfo.getRepositoryId() + "</id><username>");
-                    w.write(releaseInfo.getUsername());
+                    // XML-escape every injected value to prevent settings.xml injection
+                    // (e.g. an attacker-controlled username/password breaking out into <mirror> elements).
+                    w.write("<settings><servers><server><id>" + StringEscapeUtils.escapeXml(releaseInfo.getRepositoryId()) + "</id><username>");
+                    w.write(StringEscapeUtils.escapeXml(releaseInfo.getUsername()));
                     w.write("</username><password>");
-                    w.write(releaseInfo.getPassword());
+                    w.write(StringEscapeUtils.escapeXml(releaseInfo.getPassword()));
                     w.write("</password></server></servers></settings>");
                 }
             }

--- a/src/main/java/org/jahia/modules/forge/actions/CreateEntryFromJar.java
+++ b/src/main/java/org/jahia/modules/forge/actions/CreateEntryFromJar.java
@@ -82,10 +82,12 @@ public class CreateEntryFromJar extends Action {
     private static final String[] EMPTY_REFERENCES = new String[]{"none"};
     private static final String JNT_FORGEMODULEVERSION = "jnt:forgeModuleVersion";
     private static final String JNT_FORGEPACKAGEVERSION = "jnt:forgePackageVersion";
+    private static final String JNT_CONTENT_FOLDER = "jnt:contentFolder";
     private static final String REDIRECT_URL = "redirectURL";
     private static final String BUNDLE_SYMBOLIC_NAME = "Bundle-SymbolicName";
     private static final String REQUIRED_VERSION = "requiredVersion";
     private static final String VERSION_NUMBER = "versionNumber";
+    private static final String VERSION_PREFIX = "version-";
     private static final String DESCRIPTION = "description";
     private static final String AUTHOR_URL = "authorURL";
     private static final String ERROR = "error";
@@ -93,6 +95,28 @@ public class CreateEntryFromJar extends Action {
     private static final String OWNER = "owner";
     private static final String MODULES_LIST = "modulesList";
     private static final String RESOURCES_PRIVATEAPPSTORE = "resources.privateappstore";
+    private static final String GROUP_ID = "groupId";
+    private static final String MODULE_NAME = "moduleName";
+    private static final String CATEGORY = "category";
+    private static final String AUTHOR_NAME_DISPLAYED_AS = "authorNameDisplayedAs";
+    private static final String AUTHOR_EMAIL = "authorEmail";
+    private static final String CODE_REPOSITORY = "codeRepository";
+    private static final String DOWNLOAD_COUNT = "downloadCount";
+    private static final String SUPPORTED_BY_JAHIA = "supportedByJahia";
+    private static final String REVIEWED_BY_JAHIA = "reviewedByJahia";
+    private static final String PUBLISHED = "published";
+    private static final String DELETED = "deleted";
+    private static final String SCREENSHOTS = "screenshots";
+    private static final String VIDEO = "video";
+    private static final String CHANGE_LOG = "changeLog";
+    private static final String FILE_DSA_SIGNATURE = "fileDsaSignature";
+    private static final String REFERENCES = "references";
+    private static final String SUCCESS_REDIRECT_URL = "successRedirectUrl";
+    private static final String SUCCESS_REDIRECT_ABSOLUTE_URL = "successRedirectAbsoluteUrl";
+    private static final String ERR_UNABLE_READ_FILE = "forge.uploadJar.error.unable.read.file";
+    private static final String ERR_MISSING_MANIFEST_ATTRIBUTE = "forge.uploadJar.error.missing.manifest.attribute";
+    private static final String ERR_VERSION_NUMBER = "forge.uploadJar.error.versionNumber";
+    private static final String LOG_UNSAFE_REDIRECT = "CreateEntryFromJar: rejected unsafe redirectURL '{}'";
     /** Maximum accepted size for an uploaded artifact (guards against resource-exhaustion uploads). */
     private static final long MAX_UPLOAD_SIZE_BYTES = 200L * 1024 * 1024;
     /** Maximum size of a single tar entry we read into memory (guards against decompression bombs). */
@@ -106,13 +130,14 @@ public class CreateEntryFromJar extends Action {
 
         DiskFileItem uploadedFile = fu.getFileItems().get("file");
         if (uploadedFile == null) {
-            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.unable.read.file", session.getLocale());
+            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, ERR_UNABLE_READ_FILE, session.getLocale());
             return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
         }
         if (uploadedFile.getSize() > MAX_UPLOAD_SIZE_BYTES) {
-            logger.warn("CreateEntryFromJar: rejected oversized upload '{}' ({} bytes)", uploadedFile.getName(), uploadedFile.getSize());
+            logger.warn("CreateEntryFromJar: rejected oversized upload '{}' ({} bytes)",
+                    ActionSecurityUtils.sanitizeForLog(uploadedFile.getName()), uploadedFile.getSize());
             uploadedFile.delete();
-            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.unable.read.file", session.getLocale());
+            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, ERR_UNABLE_READ_FILE, session.getLocale());
             return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
         }
         String filename = uploadedFile.getName();
@@ -131,7 +156,7 @@ public class CreateEntryFromJar extends Action {
                         if (entry.isFile() && entry.getName().equals("package/package.json")) {
                             if (entry.getSize() > MAX_TAR_ENTRY_SIZE_BYTES) {
                                 logger.warn("CreateEntryFromJar: package.json entry too large ({} bytes) - rejected", entry.getSize());
-                                String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.unable.read.file", session.getLocale());
+                                String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, ERR_UNABLE_READ_FILE, session.getLocale());
                                 return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
                             }
                             final JSONObject jsonObject = new JSONObject(IOUtils.toString(tarInputStream, "UTF-8"));
@@ -143,7 +168,7 @@ public class CreateEntryFromJar extends Action {
                     return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
                 } catch (IOException ex) {
                     logger.error("Impossible to parse archive", ex);
-                    String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.unable.read.file", session.getLocale());
+                    String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, ERR_UNABLE_READ_FILE, session.getLocale());
                     return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
                 }finally {
                     uploadedFile.delete();
@@ -164,7 +189,7 @@ public class CreateEntryFromJar extends Action {
                     }
                 } catch (IOException ex) {
                     logger.error("Impossible to parse archive", ex);
-                    String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.unable.read.file", session.getLocale());
+                    String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, ERR_UNABLE_READ_FILE, session.getLocale());
                     return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
                 } finally {
                     uploadedFile.delete();
@@ -185,16 +210,16 @@ public class CreateEntryFromJar extends Action {
         final String groupId = mavenJsonObject.getString("groupId");
         final JCRSiteNode site = resource.getNode().getResolveSite();
         final Map<String, List<String>> moduleParams = new HashMap<>();
-        moduleParams.put("moduleName", Arrays.asList(moduleName));
-        moduleParams.put("groupId", Arrays.asList(groupId));
+        moduleParams.put(MODULE_NAME, Arrays.asList(moduleName));
+        moduleParams.put(GROUP_ID, Arrays.asList(groupId));
         moduleParams.put(Constants.JCR_TITLE, Arrays.asList(moduleName));
         moduleParams.put(VERSION_NUMBER, Arrays.asList(version));
 
         final String forgeUrl = StringUtils.substringBefore(request.getRequestURL().toString(), "/render");
         final String reqVersionAttribute = jahiaJsonObject.getString("required-version");
-        final String requiredVersion = "version-" + reqVersionAttribute;
+        final String requiredVersion = VERSION_PREFIX + reqVersionAttribute;
         if (StringUtils.isEmpty(moduleName) || StringUtils.isEmpty(groupId) || StringUtils.isEmpty(reqVersionAttribute)) {
-            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.missing.manifest.attribute", session.getLocale());
+            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, ERR_MISSING_MANIFEST_ATTRIBUTE, session.getLocale());
             return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
         }
         final String moduleRelPath = groupId.replace(".", "/") + "/" + moduleName;
@@ -206,8 +231,8 @@ public class CreateEntryFromJar extends Action {
         // TODO: upload Javascript module
 
         // Create module
-        final List<String> moduleParamKeys = Arrays.asList(DESCRIPTION, "category", "icon", "authorNameDisplayedAs", AUTHOR_URL, "authorEmail", "FAQ", "codeRepository", "downloadCount", "supportedByJahia", "reviewedByJahia", "published", "deleted", "screenshots", "video", "groupId");
-        final List<String> versionParamKeys = Arrays.asList(REQUIRED_VERSION, VERSION_NUMBER, "fileDsaSignature", "changeLog", "url");
+        final List<String> moduleParamKeys = Arrays.asList(DESCRIPTION, CATEGORY, "icon", AUTHOR_NAME_DISPLAYED_AS, AUTHOR_URL, AUTHOR_EMAIL, "FAQ", CODE_REPOSITORY, DOWNLOAD_COUNT, SUPPORTED_BY_JAHIA, REVIEWED_BY_JAHIA, PUBLISHED, DELETED, SCREENSHOTS, VIDEO, GROUP_ID);
+        final List<String> versionParamKeys = Arrays.asList(REQUIRED_VERSION, VERSION_NUMBER, FILE_DSA_SIGNATURE, CHANGE_LOG, "url");
         final Map<String, List<String>> moduleParameters = new HashMap<>();
         final Map<String, List<String>> versionParameters = new HashMap<>();
 
@@ -238,7 +263,7 @@ public class CreateEntryFromJar extends Action {
                 if (repository.hasNode(segment)) {
                     repository = repository.getNode(segment);
                 } else {
-                    repository = repository.addNode(segment, "jnt:contentFolder");
+                    repository = repository.addNode(segment, JNT_CONTENT_FOLDER);
                 }
             }
             module = createNode(request, moduleParameters, repository, "jnt:forgeModule", moduleName, false);
@@ -261,7 +286,7 @@ public class CreateEntryFromJar extends Action {
         logger.info("Start adding module version {} of {}", version, title);
 
         if (hasModuleVersions && !hasValidVersionNumber(module, version)) {
-            String error = Messages.getWithArgs(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.versionNumber", session.getLocale(), moduleName, version);
+            String error = Messages.getWithArgs(RESOURCES_PRIVATEAPPSTORE, ERR_VERSION_NUMBER, session.getLocale(), moduleName, version);
             return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
         }
 
@@ -270,9 +295,9 @@ public class CreateEntryFromJar extends Action {
         String value = jahiaJsonObject.getString("module-dependencies");
         if (value != null) {
             String[] jahiaDepends = value.split(",");
-            moduleVersion.setProperty("references", jahiaDepends);
+            moduleVersion.setProperty(REFERENCES, jahiaDepends);
         } else {
-            moduleVersion.setProperty("references", EMPTY_REFERENCES);
+            moduleVersion.setProperty(REFERENCES, EMPTY_REFERENCES);
         }
 
         if (!session.getUser().getUsername().equals(Constants.GUEST_USERNAME)) {
@@ -291,14 +316,14 @@ public class CreateEntryFromJar extends Action {
         moduleVersion.uploadFile(uploadedFile.getName(), uploadedFile.getInputStream(), uploadedFile.getContentType());
         session.save();
         
-        final ActionResult uploadResult = new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put("successRedirectUrl", moduleUrl).put(
-                "successRedirectAbsoluteUrl", moduleAbsoluteUrl));
+        final ActionResult uploadResult = new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(SUCCESS_REDIRECT_URL, moduleUrl).put(
+                SUCCESS_REDIRECT_ABSOLUTE_URL, moduleAbsoluteUrl));
         if (formParams.containsKey(REDIRECT_URL)) {
             String redirectUrl = formParams.get(REDIRECT_URL).get(0);
-            if (isSafeRedirect(redirectUrl)) {
+            if (ActionSecurityUtils.isSafeRedirect(redirectUrl)) {
                 uploadResult.setUrl(redirectUrl);
             } else {
-                logger.warn("CreateEntryFromJar: rejected unsafe redirectURL '{}'", redirectUrl);
+                logger.warn(LOG_UNSAFE_REDIRECT, ActionSecurityUtils.sanitizeForLog(redirectUrl));
             }
         }
 
@@ -322,9 +347,9 @@ public class CreateEntryFromJar extends Action {
         packageParams.put(VERSION_NUMBER, Arrays.asList(version));
 
         String reqVersionAttribute = attributes.getValue("Jahia-Required-Version");
-        final String requiredVersion = "version-" + reqVersionAttribute;
+        final String requiredVersion = VERSION_PREFIX + reqVersionAttribute;
         if (StringUtils.isEmpty(packageName) || StringUtils.isEmpty(reqVersionAttribute) || StringUtils.isEmpty(version)) {
-            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.missing.manifest.attribute", session.getLocale());
+            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, ERR_MISSING_MANIFEST_ATTRIBUTE, session.getLocale());
             return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
         }
         JCRNodeWrapper versions = getJahiaVersion(requiredVersion, resource, session);
@@ -332,8 +357,8 @@ public class CreateEntryFromJar extends Action {
         packageParams.put(REQUIRED_VERSION, Arrays.asList(versions.getNode(requiredVersion).getIdentifier()));
 
         // Create package
-        List<String> packageParamKeys = Arrays.asList(DESCRIPTION, "category", "icon", "authorNameDisplayedAs", AUTHOR_URL, "authorEmail", "FAQ", "downloadCount", "supportedByJahia", "reviewedByJahia", "published", "deleted", "screenshots", "video");
-        List<String> versionParamKeys = Arrays.asList(REQUIRED_VERSION, VERSION_NUMBER, "fileDsaSignature", "changeLog");
+        List<String> packageParamKeys = Arrays.asList(DESCRIPTION, CATEGORY, "icon", AUTHOR_NAME_DISPLAYED_AS, AUTHOR_URL, AUTHOR_EMAIL, "FAQ", DOWNLOAD_COUNT, SUPPORTED_BY_JAHIA, REVIEWED_BY_JAHIA, PUBLISHED, DELETED, SCREENSHOTS, VIDEO);
+        List<String> versionParamKeys = Arrays.asList(REQUIRED_VERSION, VERSION_NUMBER, FILE_DSA_SIGNATURE, CHANGE_LOG);
         Map<String, List<String>> packageParameters = new HashMap<>();
         Map<String, List<String>> versionParameters = new HashMap<>();
 
@@ -383,7 +408,7 @@ public class CreateEntryFromJar extends Action {
         logger.info("Start adding package version {} of {}", version, title);
 
         if (hasPackageVersions && !hasValidVersionNumber(modulesPackage, version)) {
-            String error = Messages.getWithArgs(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.versionNumber", session.getLocale(), packageName, version);
+            String error = Messages.getWithArgs(RESOURCES_PRIVATEAPPSTORE, ERR_VERSION_NUMBER, session.getLocale(), packageName, version);
             return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
         }
 
@@ -431,14 +456,14 @@ public class CreateEntryFromJar extends Action {
 
         session.save();
 
-        ActionResult uploadResult = new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put("successRedirectUrl", packageUrl).put(
-                "successRedirectAbsoluteUrl", packageAbsoluteUrl));
+        ActionResult uploadResult = new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(SUCCESS_REDIRECT_URL, packageUrl).put(
+                SUCCESS_REDIRECT_ABSOLUTE_URL, packageAbsoluteUrl));
         if (formParams.containsKey(REDIRECT_URL)) {
             String redirectUrl = formParams.get(REDIRECT_URL).get(0);
-            if (isSafeRedirect(redirectUrl)) {
+            if (ActionSecurityUtils.isSafeRedirect(redirectUrl)) {
                 uploadResult.setUrl(redirectUrl);
             } else {
-                logger.warn("CreateEntryFromJar: rejected unsafe redirectURL '{}'", redirectUrl);
+                logger.warn(LOG_UNSAFE_REDIRECT, ActionSecurityUtils.sanitizeForLog(redirectUrl));
             }
         }
 
@@ -459,8 +484,8 @@ public class CreateEntryFromJar extends Action {
         JCRSiteNode site = resource.getNode().getResolveSite();
         String forgeSettingsUrl = site.getProperty("forgeSettingsUrl").getString();
 
-        moduleParams.put("moduleName", Arrays.asList(moduleName));
-        moduleParams.put("groupId", Arrays.asList(groupId));
+        moduleParams.put(MODULE_NAME, Arrays.asList(moduleName));
+        moduleParams.put(GROUP_ID, Arrays.asList(groupId));
         moduleParams.put(Constants.JCR_TITLE, Arrays.asList(attributes.getValue("Implementation-Title")));
         moduleParams.put(DESCRIPTION, Arrays.asList(attributes.getValue("Bundle-Description")));
         moduleParams.put(AUTHOR_URL, Arrays.asList(attributes.getValue("Implementation-URL")));
@@ -470,9 +495,9 @@ public class CreateEntryFromJar extends Action {
 
         String forgeUrl = StringUtils.substringBefore(request.getRequestURL().toString(), "/render");
         String reqVersionAttribute = attributes.getValue("Jahia-Required-Version");
-        final String requiredVersion = "version-" + reqVersionAttribute;
+        final String requiredVersion = VERSION_PREFIX + reqVersionAttribute;
         if (StringUtils.isEmpty(moduleName) || StringUtils.isEmpty(groupId) || StringUtils.isEmpty(reqVersionAttribute)) {
-            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.missing.manifest.attribute", session.getLocale());
+            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, ERR_MISSING_MANIFEST_ATTRIBUTE, session.getLocale());
             return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
         }
         String moduleRelPath = groupId.replace(".", "/") + "/" + moduleName;
@@ -505,8 +530,8 @@ public class CreateEntryFromJar extends Action {
 
         // Create module
 
-        List<String> moduleParamKeys = Arrays.asList(DESCRIPTION, "category", "icon", "authorNameDisplayedAs", AUTHOR_URL, "authorEmail", "FAQ", "codeRepository", "downloadCount", "supportedByJahia", "reviewedByJahia", "published", "deleted", "screenshots", "video", "groupId");
-        List<String> versionParamKeys = Arrays.asList(REQUIRED_VERSION, VERSION_NUMBER, "fileDsaSignature", "changeLog", "url");
+        List<String> moduleParamKeys = Arrays.asList(DESCRIPTION, CATEGORY, "icon", AUTHOR_NAME_DISPLAYED_AS, AUTHOR_URL, AUTHOR_EMAIL, "FAQ", CODE_REPOSITORY, DOWNLOAD_COUNT, SUPPORTED_BY_JAHIA, REVIEWED_BY_JAHIA, PUBLISHED, DELETED, SCREENSHOTS, VIDEO, GROUP_ID);
+        List<String> versionParamKeys = Arrays.asList(REQUIRED_VERSION, VERSION_NUMBER, FILE_DSA_SIGNATURE, CHANGE_LOG, "url");
         Map<String, List<String>> moduleParameters = new HashMap<>();
         Map<String, List<String>> versionParameters = new HashMap<>();
 
@@ -537,7 +562,7 @@ public class CreateEntryFromJar extends Action {
                 if (repository.hasNode(segment)) {
                     repository = repository.getNode(segment);
                 } else {
-                    repository = repository.addNode(segment, "jnt:contentFolder");
+                    repository = repository.addNode(segment, JNT_CONTENT_FOLDER);
                 }
             }
             module = createNode(request, moduleParameters, repository, "jnt:forgeModule", moduleName, false);
@@ -560,7 +585,7 @@ public class CreateEntryFromJar extends Action {
         logger.info("Start adding module version {} of {}", version, title);
 
         if (hasModuleVersions && !hasValidVersionNumber(module, version)) {
-            String error = Messages.getWithArgs(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.versionNumber", session.getLocale(), moduleName, version);
+            String error = Messages.getWithArgs(RESOURCES_PRIVATEAPPSTORE, ERR_VERSION_NUMBER, session.getLocale(), moduleName, version);
             return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
         }
 
@@ -569,9 +594,9 @@ public class CreateEntryFromJar extends Action {
         String value = attributes.getValue("Jahia-Depends");
         if (value != null) {
             String[] jahiaDepends = value.split(",");
-            moduleVersion.setProperty("references", jahiaDepends);
+            moduleVersion.setProperty(REFERENCES, jahiaDepends);
         } else {
-            moduleVersion.setProperty("references", EMPTY_REFERENCES);
+            moduleVersion.setProperty(REFERENCES, EMPTY_REFERENCES);
         }
 
         if (!session.getUser().getUsername().equals(Constants.GUEST_USERNAME)) {
@@ -587,33 +612,18 @@ public class CreateEntryFromJar extends Action {
         String moduleUrl = renderContext.getResponse().encodeURL(module.getUrl());
         String moduleAbsoluteUrl = module.getProvider().getAbsoluteContextPath(request) + moduleUrl;
         session.save();
-        ActionResult uploadResult = new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put("successRedirectUrl", moduleUrl).put(
-                "successRedirectAbsoluteUrl", moduleAbsoluteUrl));
+        ActionResult uploadResult = new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(SUCCESS_REDIRECT_URL, moduleUrl).put(
+                SUCCESS_REDIRECT_ABSOLUTE_URL, moduleAbsoluteUrl));
         if (formParams.containsKey(REDIRECT_URL)) {
             String redirectUrl = formParams.get(REDIRECT_URL).get(0);
-            if (isSafeRedirect(redirectUrl)) {
+            if (ActionSecurityUtils.isSafeRedirect(redirectUrl)) {
                 uploadResult.setUrl(redirectUrl);
             } else {
-                logger.warn("CreateEntryFromJar: rejected unsafe redirectURL '{}'", redirectUrl);
+                logger.warn(LOG_UNSAFE_REDIRECT, ActionSecurityUtils.sanitizeForLog(redirectUrl));
             }
         }
 
         return uploadResult;
-    }
-
-    /**
-     * Only allow site-relative redirect targets. Rejects absolute URLs, protocol-relative URLs
-     * and pseudo-schemes (javascript:, data:, ...) to prevent open redirect / XSS after upload.
-     */
-    private static boolean isSafeRedirect(String url) {
-        if (StringUtils.isBlank(url)) {
-            return false;
-        }
-        String lower = url.trim().toLowerCase();
-        return lower.startsWith("/")
-                && !lower.startsWith("//")
-                && !lower.startsWith("/\\")
-                && !lower.contains("://");
     }
 
     public void setMavenExecutable(String mavenExecutable) {
@@ -679,9 +689,9 @@ public class CreateEntryFromJar extends Action {
                     w.write("</password></server></servers></settings>");
                 }
             }
-            JarFile jar = new JarFile(generatedJar);
-            pomFile = PomUtils.extractPomFromJar(jar, groupId, artifactId);
-            jar.close();
+            try (JarFile jar = new JarFile(generatedJar)) {
+                pomFile = PomUtils.extractPomFromJar(jar, groupId, artifactId);
+            }
 
             Model pom;
             try {

--- a/src/main/java/org/jahia/modules/forge/actions/CreateEntryFromJar.java
+++ b/src/main/java/org/jahia/modules/forge/actions/CreateEntryFromJar.java
@@ -133,8 +133,10 @@ public class CreateEntryFromJar extends Action {
             return errorResult(session, ERR_UNABLE_READ_FILE);
         }
         if (uploadedFile.getSize() > MAX_UPLOAD_SIZE_BYTES) {
-            logger.warn("CreateEntryFromJar: rejected oversized upload '{}' ({} bytes)",
-                    ActionSecurityUtils.sanitizeForLog(uploadedFile.getName()), uploadedFile.getSize());
+            if (logger.isWarnEnabled()) {
+                logger.warn("CreateEntryFromJar: rejected oversized upload '{}' ({} bytes)",
+                        ActionSecurityUtils.sanitizeForLog(uploadedFile.getName()), uploadedFile.getSize());
+            }
             uploadedFile.delete();
             return errorResult(session, ERR_UNABLE_READ_FILE);
         }
@@ -507,7 +509,7 @@ public class CreateEntryFromJar extends Action {
         String redirectUrl = formParams.get(REDIRECT_URL).get(0);
         if (ActionSecurityUtils.isSafeRedirect(redirectUrl)) {
             result.setUrl(redirectUrl);
-        } else {
+        } else if (logger.isWarnEnabled()) {
             logger.warn(LOG_UNSAFE_REDIRECT, ActionSecurityUtils.sanitizeForLog(redirectUrl));
         }
     }

--- a/src/main/java/org/jahia/modules/forge/actions/CreateEntryFromJar.java
+++ b/src/main/java/org/jahia/modules/forge/actions/CreateEntryFromJar.java
@@ -130,74 +130,75 @@ public class CreateEntryFromJar extends Action {
 
         DiskFileItem uploadedFile = fu.getFileItems().get("file");
         if (uploadedFile == null) {
-            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, ERR_UNABLE_READ_FILE, session.getLocale());
-            return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
+            return errorResult(session, ERR_UNABLE_READ_FILE);
         }
         if (uploadedFile.getSize() > MAX_UPLOAD_SIZE_BYTES) {
             logger.warn("CreateEntryFromJar: rejected oversized upload '{}' ({} bytes)",
                     ActionSecurityUtils.sanitizeForLog(uploadedFile.getName()), uploadedFile.getSize());
             uploadedFile.delete();
-            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, ERR_UNABLE_READ_FILE, session.getLocale());
-            return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
+            return errorResult(session, ERR_UNABLE_READ_FILE);
         }
         String filename = uploadedFile.getName();
+        if (StringUtils.contains(filename, "SNAPSHOT.")) {
+            return errorResult(session, "forge.uploadJar.error.snapshot.not.allowed");
+        }
+        String extension = StringUtils.substringAfterLast(filename, ".");
+        if (!(StringUtils.equals(extension, "jar") || StringUtils.equals(extension, "war") || StringUtils.equals(extension, "tgz"))) {
+            return errorResult(session, "forge.uploadJar.error.wrong.format");
+        }
         Map<String, List<String>> formParameters = fu.getParameterMap();
-        if (!StringUtils.contains(filename, "SNAPSHOT.")) {
-            String extension = StringUtils.substringAfterLast(filename, ".");
-            if (!(StringUtils.equals(extension, "jar") || StringUtils.equals(extension, "war") || StringUtils.equals(extension, "tgz"))) {
-                String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.wrong.format", session.getLocale());
-                return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
-            }
-            if (extension.endsWith("tgz")) {
-                try ( InputStream fileInputStream = new FileInputStream(uploadedFile.getStoreLocation());  InputStream gzipInputStream = new GZIPInputStream(fileInputStream);  TarArchiveInputStream tarInputStream = new TarArchiveInputStream(gzipInputStream)) {
+        if (extension.endsWith("tgz")) {
+            return handleTgzUpload(uploadedFile, extension, request, renderContext, resource, session, formParameters);
+        }
+        return handleJarUpload(uploadedFile, extension, request, renderContext, resource, session, formParameters);
+    }
 
-                    TarArchiveEntry entry;
-                    while ((entry = tarInputStream.getNextTarEntry()) != null) {
-                        if (entry.isFile() && entry.getName().equals("package/package.json")) {
-                            if (entry.getSize() > MAX_TAR_ENTRY_SIZE_BYTES) {
-                                logger.warn("CreateEntryFromJar: package.json entry too large ({} bytes) - rejected", entry.getSize());
-                                String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, ERR_UNABLE_READ_FILE, session.getLocale());
-                                return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
-                            }
-                            final JSONObject jsonObject = new JSONObject(IOUtils.toString(tarInputStream, "UTF-8"));
-                            return createJavascriptModule(uploadedFile, jsonObject, request, renderContext, resource, session, extension, formParameters);
-                        }
-                    }
+    private ActionResult handleTgzUpload(DiskFileItem uploadedFile, String extension, HttpServletRequest request,
+                                         RenderContext renderContext, Resource resource, JCRSessionWrapper session,
+                                         Map<String, List<String>> formParameters) throws Exception {
+        try (InputStream fileInputStream = new FileInputStream(uploadedFile.getStoreLocation());
+             InputStream gzipInputStream = new GZIPInputStream(fileInputStream);
+             TarArchiveInputStream tarInputStream = new TarArchiveInputStream(gzipInputStream)) {
 
-                    String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.unable.read.manifest", session.getLocale());
-                    return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
-                } catch (IOException ex) {
-                    logger.error("Impossible to parse archive", ex);
-                    String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, ERR_UNABLE_READ_FILE, session.getLocale());
-                    return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
-                }finally {
-                    uploadedFile.delete();
+            TarArchiveEntry entry;
+            while ((entry = tarInputStream.getNextTarEntry()) != null) {
+                if (!entry.isFile() || !"package/package.json".equals(entry.getName())) {
+                    continue;
                 }
-            } else {
-                try ( JarFile jar = new JarFile(uploadedFile.getStoreLocation());) {
-                    Manifest manifest = jar.getManifest();
-                    if (manifest != null) {
-                        Attributes attributes = manifest.getMainAttributes();
-                        if (attributes.getValue("Jahia-Package-Name") != null) {
-                            return createPackage(uploadedFile, jar, attributes, request, renderContext, resource, session, formParameters);
-                        } else {
-                            return createModule(uploadedFile, attributes, request, renderContext, resource, session, extension, formParameters);
-                        }
-                    } else {
-                        String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.unable.read.manifest", session.getLocale());
-                        return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
-                    }
-                } catch (IOException ex) {
-                    logger.error("Impossible to parse archive", ex);
-                    String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, ERR_UNABLE_READ_FILE, session.getLocale());
-                    return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
-                } finally {
-                    uploadedFile.delete();
+                if (entry.getSize() > MAX_TAR_ENTRY_SIZE_BYTES) {
+                    logger.warn("CreateEntryFromJar: package.json entry too large ({} bytes) - rejected", entry.getSize());
+                    return errorResult(session, ERR_UNABLE_READ_FILE);
                 }
+                final JSONObject jsonObject = new JSONObject(IOUtils.toString(tarInputStream, "UTF-8"));
+                return createJavascriptModule(uploadedFile, jsonObject, request, renderContext, resource, session, extension, formParameters);
             }
-        } else {
-            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.snapshot.not.allowed", session.getLocale());
-            return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
+            return errorResult(session, "forge.uploadJar.error.unable.read.manifest");
+        } catch (IOException ex) {
+            logger.error("Impossible to parse archive", ex);
+            return errorResult(session, ERR_UNABLE_READ_FILE);
+        } finally {
+            uploadedFile.delete();
+        }
+    }
+
+    private ActionResult handleJarUpload(DiskFileItem uploadedFile, String extension, HttpServletRequest request,
+                                         RenderContext renderContext, Resource resource, JCRSessionWrapper session,
+                                         Map<String, List<String>> formParameters) throws Exception {
+        try (JarFile jar = new JarFile(uploadedFile.getStoreLocation())) {
+            Manifest manifest = jar.getManifest();
+            if (manifest == null) {
+                return errorResult(session, "forge.uploadJar.error.unable.read.manifest");
+            }
+            Attributes attributes = manifest.getMainAttributes();
+            if (attributes.getValue("Jahia-Package-Name") != null) {
+                return createPackage(uploadedFile, jar, attributes, request, renderContext, resource, session, formParameters);
+            }
+            return createModule(uploadedFile, attributes, request, renderContext, resource, session, extension, formParameters);
+        } catch (IOException ex) {
+            logger.error("Impossible to parse archive", ex);
+            return errorResult(session, ERR_UNABLE_READ_FILE);
+        } finally {
+            uploadedFile.delete();
         }
     }
     
@@ -207,7 +208,7 @@ public class CreateEntryFromJar extends Action {
         final String moduleName = jsonObject.getString("name");
         final JSONObject jahiaJsonObject = jsonObject.getJSONObject("jahia");
         final JSONObject mavenJsonObject = jahiaJsonObject.getJSONObject("maven");
-        final String groupId = mavenJsonObject.getString("groupId");
+        final String groupId = mavenJsonObject.getString(GROUP_ID);
         final JCRSiteNode site = resource.getNode().getResolveSite();
         final Map<String, List<String>> moduleParams = new HashMap<>();
         moduleParams.put(MODULE_NAME, Arrays.asList(moduleName));
@@ -219,8 +220,7 @@ public class CreateEntryFromJar extends Action {
         final String reqVersionAttribute = jahiaJsonObject.getString("required-version");
         final String requiredVersion = VERSION_PREFIX + reqVersionAttribute;
         if (StringUtils.isEmpty(moduleName) || StringUtils.isEmpty(groupId) || StringUtils.isEmpty(reqVersionAttribute)) {
-            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, ERR_MISSING_MANIFEST_ATTRIBUTE, session.getLocale());
-            return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
+            return errorResult(session, ERR_MISSING_MANIFEST_ATTRIBUTE);
         }
         final String moduleRelPath = groupId.replace(".", "/") + "/" + moduleName;
         moduleParams.put("url", Arrays.asList(forgeUrl + "/mavenproxy/" + site.getName() + "/" + moduleRelPath + "/" + version + "/" + moduleName + "-" + version + "." + extension));
@@ -228,9 +228,6 @@ public class CreateEntryFromJar extends Action {
         final JCRNodeWrapper versions = getJahiaVersion(requiredVersion, resource, session);
         moduleParams.put(REQUIRED_VERSION, Arrays.asList(versions.getNode(requiredVersion).getIdentifier()));
 
-        // TODO: upload Javascript module
-
-        // Create module
         final List<String> moduleParamKeys = Arrays.asList(DESCRIPTION, CATEGORY, "icon", AUTHOR_NAME_DISPLAYED_AS, AUTHOR_URL, AUTHOR_EMAIL, "FAQ", CODE_REPOSITORY, DOWNLOAD_COUNT, SUPPORTED_BY_JAHIA, REVIEWED_BY_JAHIA, PUBLISHED, DELETED, SCREENSHOTS, VIDEO, GROUP_ID);
         final List<String> versionParamKeys = Arrays.asList(REQUIRED_VERSION, VERSION_NUMBER, FILE_DSA_SIGNATURE, CHANGE_LOG, "url");
         final Map<String, List<String>> moduleParameters = new HashMap<>();
@@ -240,49 +237,16 @@ public class CreateEntryFromJar extends Action {
         if (StringUtils.isEmpty(title)) {
             title = moduleName;
         }
-        // manually add jcr:title
         moduleParameters.put(Constants.JCR_TITLE, Arrays.asList(title));
         versionParameters.put(Constants.JCR_TITLE, Arrays.asList(title));
-
-        for (Map.Entry<String, List<String>> moduleParam : moduleParams.entrySet()) {
-            final String moduleParamKey = moduleParam.getKey();
-            final List<String> moduleParamValue = moduleParam.getValue();
-            if (moduleParamKeys.contains(moduleParamKey) && moduleParamValue.get(0) != null) {
-                moduleParameters.put(moduleParamKey, moduleParamValue);
-            } else if (versionParamKeys.contains(moduleParamKey) && moduleParamValue.get(0) != null) {
-                versionParameters.put(moduleParamKey, moduleParamValue);
-            }
-        }
+        partitionParams(moduleParams, moduleParamKeys, versionParamKeys, moduleParameters, versionParameters);
 
         logger.info("Start creating Private App Store Javascript Module {}", moduleName);
 
-        JCRNodeWrapper module;
-
-        if (!repository.hasNode(moduleRelPath)) {
-            for (String segment : groupId.split("\\.")) {
-                if (repository.hasNode(segment)) {
-                    repository = repository.getNode(segment);
-                } else {
-                    repository = repository.addNode(segment, JNT_CONTENT_FOLDER);
-                }
-            }
-            module = createNode(request, moduleParameters, repository, "jnt:forgeModule", moduleName, false);
-        } else {
-            module = repository.getNode(moduleRelPath);
-            moduleParameters.remove(DESCRIPTION);
-            moduleParameters.remove(Constants.JCR_TITLE);
-            setProperties(module, moduleParameters);
-        }
-
-        if (!session.getUser().getUsername().equals(Constants.GUEST_USERNAME)) {
-            List<String> roles = Arrays.asList(OWNER);
-            module.grantRoles("u:" + session.getUser().getUsername(), new HashSet<String>(roles));
-        }
+        JCRNodeWrapper module = upsertModuleNode(request, repository, moduleRelPath, groupId, moduleName, moduleParameters);
+        grantOwnerRole(session, module);
 
         boolean hasModuleVersions = JCRTagUtils.hasChildrenOfType(module, JNT_FORGEMODULEVERSION);
-
-        // create module version
-
         logger.info("Start adding module version {} of {}", version, title);
 
         if (hasModuleVersions && !hasValidVersionNumber(module, version)) {
@@ -294,38 +258,24 @@ public class CreateEntryFromJar extends Action {
 
         String value = jahiaJsonObject.getString("module-dependencies");
         if (value != null) {
-            String[] jahiaDepends = value.split(",");
-            moduleVersion.setProperty(REFERENCES, jahiaDepends);
+            moduleVersion.setProperty(REFERENCES, value.split(","));
         } else {
             moduleVersion.setProperty(REFERENCES, EMPTY_REFERENCES);
         }
-
-        if (!session.getUser().getUsername().equals(Constants.GUEST_USERNAME)) {
-            List<String> roles = Arrays.asList(OWNER);
-            moduleVersion.grantRoles("u:" + session.getUser().getUsername(), new HashSet<String>(roles));
-        }
+        grantOwnerRole(session, moduleVersion);
 
         logger.info("Javascript Module version {} of {} successfully added", version, title);
-
-        logger.info("Private App Store Javascript Module {} successfully created and added to repository {}", moduleName,
-                repository.getPath());
+        logger.info("Private App Store Javascript Module {} successfully created and added to repository {}", moduleName, repository.getPath());
 
         final String moduleUrl = renderContext.getResponse().encodeURL(module.getUrl());
         final String moduleAbsoluteUrl = module.getProvider().getAbsoluteContextPath(request) + moduleUrl;
         session.save();
         moduleVersion.uploadFile(uploadedFile.getName(), uploadedFile.getInputStream(), uploadedFile.getContentType());
         session.save();
-        
+
         final ActionResult uploadResult = new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(SUCCESS_REDIRECT_URL, moduleUrl).put(
                 SUCCESS_REDIRECT_ABSOLUTE_URL, moduleAbsoluteUrl));
-        if (formParams.containsKey(REDIRECT_URL)) {
-            String redirectUrl = formParams.get(REDIRECT_URL).get(0);
-            if (ActionSecurityUtils.isSafeRedirect(redirectUrl)) {
-                uploadResult.setUrl(redirectUrl);
-            } else {
-                logger.warn(LOG_UNSAFE_REDIRECT, ActionSecurityUtils.sanitizeForLog(redirectUrl));
-            }
-        }
+        applySafeRedirect(uploadResult, formParams);
 
         return uploadResult;
     }
@@ -349,14 +299,11 @@ public class CreateEntryFromJar extends Action {
         String reqVersionAttribute = attributes.getValue("Jahia-Required-Version");
         final String requiredVersion = VERSION_PREFIX + reqVersionAttribute;
         if (StringUtils.isEmpty(packageName) || StringUtils.isEmpty(reqVersionAttribute) || StringUtils.isEmpty(version)) {
-            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, ERR_MISSING_MANIFEST_ATTRIBUTE, session.getLocale());
-            return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
+            return errorResult(session, ERR_MISSING_MANIFEST_ATTRIBUTE);
         }
         JCRNodeWrapper versions = getJahiaVersion(requiredVersion, resource, session);
-
         packageParams.put(REQUIRED_VERSION, Arrays.asList(versions.getNode(requiredVersion).getIdentifier()));
 
-        // Create package
         List<String> packageParamKeys = Arrays.asList(DESCRIPTION, CATEGORY, "icon", AUTHOR_NAME_DISPLAYED_AS, AUTHOR_URL, AUTHOR_EMAIL, "FAQ", DOWNLOAD_COUNT, SUPPORTED_BY_JAHIA, REVIEWED_BY_JAHIA, PUBLISHED, DELETED, SCREENSHOTS, VIDEO);
         List<String> versionParamKeys = Arrays.asList(REQUIRED_VERSION, VERSION_NUMBER, FILE_DSA_SIGNATURE, CHANGE_LOG);
         Map<String, List<String>> packageParameters = new HashMap<>();
@@ -366,45 +313,16 @@ public class CreateEntryFromJar extends Action {
         if (StringUtils.isEmpty(title)) {
             title = packageName;
         }
-
-        // manually add jcr:title
         packageParameters.put(Constants.JCR_TITLE, Arrays.asList(title));
         versionParameters.put(Constants.JCR_TITLE, Arrays.asList(title));
-
-        for (Map.Entry<String, List<String>> packageParam : packageParams.entrySet()) {
-            String packageParamKey = packageParam.getKey();
-            List<String> packageParamValue = packageParam.getValue();
-            if (packageParamKeys.contains(packageParamKey) && packageParamValue.get(0) != null) {
-                packageParameters.put(packageParamKey, packageParamValue);
-            } else if (versionParamKeys.contains(packageParamKey) && packageParamValue.get(0) != null) {
-                versionParameters.put(packageParamKey, packageParamValue);
-            }
-        }
+        partitionParams(packageParams, packageParamKeys, versionParamKeys, packageParameters, versionParameters);
 
         logger.info("Start creating Private App Store Package {}", packageName);
 
-        if (!repository.hasNode(packageRelPath)) {
-            if (repository.hasNode(PACKAGES)) {
-                repository = repository.getNode(PACKAGES);
-            } else {
-                repository = repository.addNode(PACKAGES, "jnt:contentFolder");
-            }
-            modulesPackage = createNode(request, packageParameters, repository, "jnt:forgePackage", packageName, false);
-        } else {
-            modulesPackage = repository.getNode(packageRelPath);
-            packageParameters.remove(DESCRIPTION);
-            packageParameters.remove(Constants.JCR_TITLE);
-            setProperties(modulesPackage, packageParameters);
-        }
-
-        if (!session.getUser().getUsername().equals(Constants.GUEST_USERNAME)) {
-            List<String> roles = Arrays.asList(OWNER);
-            modulesPackage.grantRoles("u:" + session.getUser().getUsername(), new HashSet<String>(roles));
-        }
+        modulesPackage = upsertPackageNode(request, repository, packageRelPath, packageName, packageParameters);
+        grantOwnerRole(session, modulesPackage);
 
         boolean hasPackageVersions = JCRTagUtils.hasChildrenOfType(modulesPackage, JNT_FORGEPACKAGEVERSION);
-
-        // create package version
         logger.info("Start adding package version {} of {}", version, title);
 
         if (hasPackageVersions && !hasValidVersionNumber(modulesPackage, version)) {
@@ -413,61 +331,55 @@ public class CreateEntryFromJar extends Action {
         }
 
         JCRNodeWrapper packageVersion = createNode(request, versionParameters, modulesPackage, JNT_FORGEPACKAGEVERSION, modulesPackage.getName() + "-" + version, false);
-
-        if (!session.getUser().getUsername().equals(Constants.GUEST_USERNAME)) {
-            List<String> roles = Arrays.asList(OWNER);
-            packageVersion.grantRoles("u:" + session.getUser().getUsername(), new HashSet<String>(roles));
-        }
-
+        grantOwnerRole(session, packageVersion);
         packageVersion.uploadFile(uploadedFile.getName(), uploadedFile.getInputStream(), uploadedFile.getContentType());
 
         logger.info("Package version {} of {} successfully added", version, title);
 
-        // create modules list
-        JCRNodeWrapper modulesList;
+        populatePackageModulesList(packageVersion, jar);
 
-        if (packageVersion.hasNode(MODULES_LIST)) {
-            modulesList = packageVersion.getNode(MODULES_LIST);
-        } else {
-            modulesList = packageVersion.addNode(MODULES_LIST, "jnt:forgePackageModulesList");
-        }
-
-        // Get list of modules from package
-        Map<String, ModulesPackage.PackagedModule> packagedModuleMap = ModulesPackage.create(jar).getModules();
-
-        for (ModulesPackage.PackagedModule packagedModule : packagedModuleMap.values()) {
-            JCRNodeWrapper module;
-
-            if (modulesList.hasNode(packagedModule.getManifestAttributes().getValue(BUNDLE_SYMBOLIC_NAME))) {
-                module = modulesList.getNode(packagedModule.getManifestAttributes().getValue(BUNDLE_SYMBOLIC_NAME));
-            } else {
-                module = modulesList.addNode(packagedModule.getManifestAttributes().getValue(BUNDLE_SYMBOLIC_NAME), "jnt:forgePackageModule");
-            }
-
-            module.setProperty("moduleName", packagedModule.getManifestAttributes().getValue("Implementation-Title"));
-            module.setProperty("moduleVersion", packagedModule.getManifestAttributes().getValue("Implementation-Version"));
-        }
-
-        logger.info("Private App Store Package {} successfully created and added to repository {}", packageName,
-                repository.getPath());
+        logger.info("Private App Store Package {} successfully created and added to repository {}", packageName, modulesPackage.getParent().getPath());
 
         String packageUrl = renderContext.getResponse().encodeURL(modulesPackage.getUrl());
         String packageAbsoluteUrl = modulesPackage.getProvider().getAbsoluteContextPath(request) + packageUrl;
-
         session.save();
 
         ActionResult uploadResult = new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(SUCCESS_REDIRECT_URL, packageUrl).put(
                 SUCCESS_REDIRECT_ABSOLUTE_URL, packageAbsoluteUrl));
-        if (formParams.containsKey(REDIRECT_URL)) {
-            String redirectUrl = formParams.get(REDIRECT_URL).get(0);
-            if (ActionSecurityUtils.isSafeRedirect(redirectUrl)) {
-                uploadResult.setUrl(redirectUrl);
-            } else {
-                logger.warn(LOG_UNSAFE_REDIRECT, ActionSecurityUtils.sanitizeForLog(redirectUrl));
-            }
-        }
-
+        applySafeRedirect(uploadResult, formParams);
         return uploadResult;
+    }
+
+    private JCRNodeWrapper upsertPackageNode(HttpServletRequest request, JCRNodeWrapper repositoryStart,
+                                             String packageRelPath, String packageName,
+                                             Map<String, List<String>> packageParameters) throws RepositoryException {
+        if (!repositoryStart.hasNode(packageRelPath)) {
+            JCRNodeWrapper packagesFolder = repositoryStart.hasNode(PACKAGES)
+                    ? repositoryStart.getNode(PACKAGES)
+                    : repositoryStart.addNode(PACKAGES, JNT_CONTENT_FOLDER);
+            return createNode(request, packageParameters, packagesFolder, "jnt:forgePackage", packageName, false);
+        }
+        JCRNodeWrapper modulesPackage = repositoryStart.getNode(packageRelPath);
+        packageParameters.remove(DESCRIPTION);
+        packageParameters.remove(Constants.JCR_TITLE);
+        setProperties(modulesPackage, packageParameters);
+        return modulesPackage;
+    }
+
+    private static void populatePackageModulesList(JCRNodeWrapper packageVersion, JarFile jar) throws RepositoryException, IOException {
+        JCRNodeWrapper modulesList = packageVersion.hasNode(MODULES_LIST)
+                ? packageVersion.getNode(MODULES_LIST)
+                : packageVersion.addNode(MODULES_LIST, "jnt:forgePackageModulesList");
+
+        Map<String, ModulesPackage.PackagedModule> packagedModuleMap = ModulesPackage.create(jar).getModules();
+        for (ModulesPackage.PackagedModule packagedModule : packagedModuleMap.values()) {
+            String symbolicName = packagedModule.getManifestAttributes().getValue(BUNDLE_SYMBOLIC_NAME);
+            JCRNodeWrapper module = modulesList.hasNode(symbolicName)
+                    ? modulesList.getNode(symbolicName)
+                    : modulesList.addNode(symbolicName, "jnt:forgePackageModule");
+            module.setProperty(MODULE_NAME, packagedModule.getManifestAttributes().getValue("Implementation-Title"));
+            module.setProperty("moduleVersion", packagedModule.getManifestAttributes().getValue("Implementation-Version"));
+        }
     }
 
     private ActionResult createModule(DiskFileItem uploadedFile, Attributes attributes, HttpServletRequest request, RenderContext renderContext, Resource resource, JCRSessionWrapper session, String extension, Map<String, List<String>> formParams) throws Exception {
@@ -489,7 +401,7 @@ public class CreateEntryFromJar extends Action {
         moduleParams.put(Constants.JCR_TITLE, Arrays.asList(attributes.getValue("Implementation-Title")));
         moduleParams.put(DESCRIPTION, Arrays.asList(attributes.getValue("Bundle-Description")));
         moduleParams.put(AUTHOR_URL, Arrays.asList(attributes.getValue("Implementation-URL")));
-        moduleParams.put("codeRepository", Arrays.asList(attributes.getValue("Jahia-Source-Control-Connection")));
+        moduleParams.put(CODE_REPOSITORY, Arrays.asList(attributes.getValue("Jahia-Source-Control-Connection")));
         moduleParams.put(VERSION_NUMBER, Arrays.asList(version));
 
 
@@ -497,16 +409,70 @@ public class CreateEntryFromJar extends Action {
         String reqVersionAttribute = attributes.getValue("Jahia-Required-Version");
         final String requiredVersion = VERSION_PREFIX + reqVersionAttribute;
         if (StringUtils.isEmpty(moduleName) || StringUtils.isEmpty(groupId) || StringUtils.isEmpty(reqVersionAttribute)) {
-            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, ERR_MISSING_MANIFEST_ATTRIBUTE, session.getLocale());
-            return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
+            return errorResult(session, ERR_MISSING_MANIFEST_ATTRIBUTE);
         }
         String moduleRelPath = groupId.replace(".", "/") + "/" + moduleName;
         moduleParams.put("url", Arrays.asList(forgeUrl + "/mavenproxy/" + site.getName() + "/" + moduleRelPath + "/" + version + "/" + moduleName + "-" + version + "." + extension));
 
         JCRNodeWrapper versions = getJahiaVersion(requiredVersion, resource, session);
-
         moduleParams.put(REQUIRED_VERSION, Arrays.asList(versions.getNode(requiredVersion).getIdentifier()));
 
+        ActionResult deployFailure = deployArtifact(uploadedFile, site, extension, groupId, moduleName, forgeSettingsUrl, session);
+        if (deployFailure != null) {
+            return deployFailure;
+        }
+
+        List<String> moduleParamKeys = Arrays.asList(DESCRIPTION, CATEGORY, "icon", AUTHOR_NAME_DISPLAYED_AS, AUTHOR_URL, AUTHOR_EMAIL, "FAQ", CODE_REPOSITORY, DOWNLOAD_COUNT, SUPPORTED_BY_JAHIA, REVIEWED_BY_JAHIA, PUBLISHED, DELETED, SCREENSHOTS, VIDEO, GROUP_ID);
+        List<String> versionParamKeys = Arrays.asList(REQUIRED_VERSION, VERSION_NUMBER, FILE_DSA_SIGNATURE, CHANGE_LOG, "url");
+        Map<String, List<String>> moduleParameters = new HashMap<>();
+        Map<String, List<String>> versionParameters = new HashMap<>();
+
+        String title = getParameter(moduleParams, Constants.JCR_TITLE);
+        if (StringUtils.isEmpty(title)) {
+            title = moduleName;
+        }
+        moduleParameters.put(Constants.JCR_TITLE, Arrays.asList(title));
+        versionParameters.put(Constants.JCR_TITLE, Arrays.asList(title));
+        partitionParams(moduleParams, moduleParamKeys, versionParamKeys, moduleParameters, versionParameters);
+
+        logger.info("Start creating Private App Store Module {}", moduleName);
+
+        JCRNodeWrapper module = upsertModuleNode(request, repository, moduleRelPath, groupId, moduleName, moduleParameters);
+        grantOwnerRole(session, module);
+
+        boolean hasModuleVersions = JCRTagUtils.hasChildrenOfType(module, JNT_FORGEMODULEVERSION);
+        logger.info("Start adding module version {} of {}", version, title);
+
+        if (hasModuleVersions && !hasValidVersionNumber(module, version)) {
+            String error = Messages.getWithArgs(RESOURCES_PRIVATEAPPSTORE, ERR_VERSION_NUMBER, session.getLocale(), moduleName, version);
+            return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
+        }
+
+        JCRNodeWrapper moduleVersion = createNode(request, versionParameters, module, JNT_FORGEMODULEVERSION, module.getName() + "-" + version, false);
+
+        String value = attributes.getValue("Jahia-Depends");
+        if (value != null) {
+            moduleVersion.setProperty(REFERENCES, value.split(","));
+        } else {
+            moduleVersion.setProperty(REFERENCES, EMPTY_REFERENCES);
+        }
+        grantOwnerRole(session, moduleVersion);
+
+        logger.info("Module version {} of {} successfully added", version, title);
+        logger.info("Private App Store Module {} successfully created and added to repository {}", moduleName, module.getParent().getPath());
+
+        String moduleUrl = renderContext.getResponse().encodeURL(module.getUrl());
+        String moduleAbsoluteUrl = module.getProvider().getAbsoluteContextPath(request) + moduleUrl;
+        session.save();
+        ActionResult uploadResult = new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(SUCCESS_REDIRECT_URL, moduleUrl).put(
+                SUCCESS_REDIRECT_ABSOLUTE_URL, moduleAbsoluteUrl));
+        applySafeRedirect(uploadResult, formParams);
+        return uploadResult;
+    }
+
+    private ActionResult deployArtifact(DiskFileItem uploadedFile, JCRSiteNode site, String extension,
+                                        String groupId, String moduleName, String forgeSettingsUrl,
+                                        JCRSessionWrapper session) throws RepositoryException, JSONException {
         String user = site.getProperty("forgeSettingsUser").getString();
         String password = new String(Base64.decode(site.getProperty("forgeSettingsPassword").getString()));
 
@@ -521,109 +487,74 @@ public class CreateEntryFromJar extends Action {
             moduleReleaseInfo.setUsername(user);
             moduleReleaseInfo.setPassword(password);
             deployToMaven(groupId, moduleName, moduleReleaseInfo, artifact);
+            return null;
         } catch (IOException e) {
-            String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, "forge.uploadJar.error.cannot.upload", session.getLocale());
-            return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
+            return errorResult(session, "forge.uploadJar.error.cannot.upload");
         } finally {
             FileUtils.deleteQuietly(artifact);
         }
+    }
 
-        // Create module
+    private static ActionResult errorResult(JCRSessionWrapper session, String messageKey) throws JSONException {
+        String error = Messages.get(RESOURCES_PRIVATEAPPSTORE, messageKey, session.getLocale());
+        return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
+    }
 
-        List<String> moduleParamKeys = Arrays.asList(DESCRIPTION, CATEGORY, "icon", AUTHOR_NAME_DISPLAYED_AS, AUTHOR_URL, AUTHOR_EMAIL, "FAQ", CODE_REPOSITORY, DOWNLOAD_COUNT, SUPPORTED_BY_JAHIA, REVIEWED_BY_JAHIA, PUBLISHED, DELETED, SCREENSHOTS, VIDEO, GROUP_ID);
-        List<String> versionParamKeys = Arrays.asList(REQUIRED_VERSION, VERSION_NUMBER, FILE_DSA_SIGNATURE, CHANGE_LOG, "url");
-        Map<String, List<String>> moduleParameters = new HashMap<>();
-        Map<String, List<String>> versionParameters = new HashMap<>();
-
-        String title = getParameter(moduleParams, Constants.JCR_TITLE);
-        if (StringUtils.isEmpty(title)) {
-            title = moduleName;
+    private static void applySafeRedirect(ActionResult result, Map<String, List<String>> formParams) {
+        if (!formParams.containsKey(REDIRECT_URL)) {
+            return;
         }
-        // manually add jcr:title
-        moduleParameters.put(Constants.JCR_TITLE, Arrays.asList(title));
-        versionParameters.put(Constants.JCR_TITLE, Arrays.asList(title));
+        String redirectUrl = formParams.get(REDIRECT_URL).get(0);
+        if (ActionSecurityUtils.isSafeRedirect(redirectUrl)) {
+            result.setUrl(redirectUrl);
+        } else {
+            logger.warn(LOG_UNSAFE_REDIRECT, ActionSecurityUtils.sanitizeForLog(redirectUrl));
+        }
+    }
 
-        for (Map.Entry<String, List<String>> moduleParam : moduleParams.entrySet()) {
-            String moduleParamKey = moduleParam.getKey();
-            List<String> moduleParamValue = moduleParam.getValue();
-            if (moduleParamKeys.contains(moduleParamKey) && moduleParamValue.get(0) != null) {
-                moduleParameters.put(moduleParamKey, moduleParamValue);
-            } else if (versionParamKeys.contains(moduleParamKey) && moduleParamValue.get(0) != null) {
-                versionParameters.put(moduleParamKey, moduleParamValue);
+    private static void grantOwnerRole(JCRSessionWrapper session, JCRNodeWrapper node) throws RepositoryException {
+        if (!session.getUser().getUsername().equals(Constants.GUEST_USERNAME)) {
+            node.grantRoles("u:" + session.getUser().getUsername(), new HashSet<>(Arrays.asList(OWNER)));
+        }
+    }
+
+    private static void partitionParams(Map<String, List<String>> source,
+                                        List<String> moduleKeys, List<String> versionKeys,
+                                        Map<String, List<String>> moduleTarget,
+                                        Map<String, List<String>> versionTarget) {
+        for (Map.Entry<String, List<String>> e : source.entrySet()) {
+            String key = e.getKey();
+            List<String> value = e.getValue();
+            if (value.get(0) == null) {
+                continue;
+            }
+            if (moduleKeys.contains(key)) {
+                moduleTarget.put(key, value);
+            } else if (versionKeys.contains(key)) {
+                versionTarget.put(key, value);
             }
         }
+    }
 
-        logger.info("Start creating Private App Store Module {}", moduleName);
-
-        JCRNodeWrapper module;
-
-        if (!repository.hasNode(moduleRelPath)) {
+    private JCRNodeWrapper upsertModuleNode(HttpServletRequest request, JCRNodeWrapper repositoryStart,
+                                            String moduleRelPath, String groupId, String moduleName,
+                                            Map<String, List<String>> moduleParameters) throws RepositoryException {
+        if (!repositoryStart.hasNode(moduleRelPath)) {
+            JCRNodeWrapper cursor = repositoryStart;
             for (String segment : groupId.split("\\.")) {
-                if (repository.hasNode(segment)) {
-                    repository = repository.getNode(segment);
+                if (cursor.hasNode(segment)) {
+                    cursor = cursor.getNode(segment);
                 } else {
-                    repository = repository.addNode(segment, JNT_CONTENT_FOLDER);
+                    cursor = cursor.addNode(segment, JNT_CONTENT_FOLDER);
                 }
             }
-            module = createNode(request, moduleParameters, repository, "jnt:forgeModule", moduleName, false);
-        } else {
-            module = repository.getNode(moduleRelPath);
-            moduleParameters.remove(DESCRIPTION);
-            moduleParameters.remove(Constants.JCR_TITLE);
-            setProperties(module, moduleParameters);
+            return createNode(request, moduleParameters, cursor, "jnt:forgeModule", moduleName, false);
         }
-
-        if (!session.getUser().getUsername().equals(Constants.GUEST_USERNAME)) {
-            List<String> roles = Arrays.asList(OWNER);
-            module.grantRoles("u:" + session.getUser().getUsername(), new HashSet<String>(roles));
-        }
-
-        boolean hasModuleVersions = JCRTagUtils.hasChildrenOfType(module, JNT_FORGEMODULEVERSION);
-
-        // create module version
-
-        logger.info("Start adding module version {} of {}", version, title);
-
-        if (hasModuleVersions && !hasValidVersionNumber(module, version)) {
-            String error = Messages.getWithArgs(RESOURCES_PRIVATEAPPSTORE, ERR_VERSION_NUMBER, session.getLocale(), moduleName, version);
-            return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(ERROR, error));
-        }
-
-        JCRNodeWrapper moduleVersion = createNode(request, versionParameters, module, JNT_FORGEMODULEVERSION, module.getName() + "-" + version, false);
-
-        String value = attributes.getValue("Jahia-Depends");
-        if (value != null) {
-            String[] jahiaDepends = value.split(",");
-            moduleVersion.setProperty(REFERENCES, jahiaDepends);
-        } else {
-            moduleVersion.setProperty(REFERENCES, EMPTY_REFERENCES);
-        }
-
-        if (!session.getUser().getUsername().equals(Constants.GUEST_USERNAME)) {
-            List<String> roles = Arrays.asList(OWNER);
-            moduleVersion.grantRoles("u:" + session.getUser().getUsername(), new HashSet<String>(roles));
-        }
-
-        logger.info("Module version {} of {} successfully added", version, title);
-
-        logger.info("Private App Store Module {} successfully created and added to repository {}", moduleName,
-                repository.getPath());
-
-        String moduleUrl = renderContext.getResponse().encodeURL(module.getUrl());
-        String moduleAbsoluteUrl = module.getProvider().getAbsoluteContextPath(request) + moduleUrl;
-        session.save();
-        ActionResult uploadResult = new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(SUCCESS_REDIRECT_URL, moduleUrl).put(
-                SUCCESS_REDIRECT_ABSOLUTE_URL, moduleAbsoluteUrl));
-        if (formParams.containsKey(REDIRECT_URL)) {
-            String redirectUrl = formParams.get(REDIRECT_URL).get(0);
-            if (ActionSecurityUtils.isSafeRedirect(redirectUrl)) {
-                uploadResult.setUrl(redirectUrl);
-            } else {
-                logger.warn(LOG_UNSAFE_REDIRECT, ActionSecurityUtils.sanitizeForLog(redirectUrl));
-            }
-        }
-
-        return uploadResult;
+        JCRNodeWrapper module = repositoryStart.getNode(moduleRelPath);
+        moduleParameters.remove(DESCRIPTION);
+        moduleParameters.remove(Constants.JCR_TITLE);
+        setProperties(module, moduleParameters);
+        return module;
     }
 
     public void setMavenExecutable(String mavenExecutable) {

--- a/src/main/java/org/jahia/modules/forge/actions/CustomMatchingTags.java
+++ b/src/main/java/org/jahia/modules/forge/actions/CustomMatchingTags.java
@@ -43,13 +43,16 @@ import java.util.Map;
  * Created by kevan on 09/09/14.
  */
 public class CustomMatchingTags extends Action {
+
+    private static final String LIMIT = "limit";
+
     private TaggingService taggingService;
 
     @Override
     public ActionResult doExecute(HttpServletRequest req, RenderContext renderContext, Resource resource, JCRSessionWrapper session, Map<String, List<String>> parameters, URLResolver urlResolver) throws Exception {
         String prefix = parameters.get("q") != null && parameters.get("q").size() > 0 ? parameters.get("q").get(0) : "";
         String path = parameters.get("path") != null && parameters.get("path").size() > 0 ? parameters.get("path").get(0) : renderContext.getSite().getPath();
-        Long limit = parameters.get("limit") != null && parameters.get("limit").size() > 0 ? Long.valueOf(parameters.get("limit").get(0)) : 10l;
+        Long limit = parameters.get(LIMIT) != null && parameters.get(LIMIT).size() > 0 ? Long.valueOf(parameters.get(LIMIT).get(0)) : 10l;
         Map<String, Long> tags = taggingService.getTagsSuggester().suggest(prefix, path, 1l, limit, 0l, true, session);
         JSONObject result = new JSONObject();
         JSONArray tagsJSON = new JSONArray();

--- a/src/main/java/org/jahia/modules/forge/actions/CustomMatchingTags.java
+++ b/src/main/java/org/jahia/modules/forge/actions/CustomMatchingTags.java
@@ -52,7 +52,7 @@ public class CustomMatchingTags extends Action {
     public ActionResult doExecute(HttpServletRequest req, RenderContext renderContext, Resource resource, JCRSessionWrapper session, Map<String, List<String>> parameters, URLResolver urlResolver) throws Exception {
         String prefix = parameters.get("q") != null && parameters.get("q").size() > 0 ? parameters.get("q").get(0) : "";
         String path = parameters.get("path") != null && parameters.get("path").size() > 0 ? parameters.get("path").get(0) : renderContext.getSite().getPath();
-        Long limit = parameters.get(LIMIT) != null && parameters.get(LIMIT).size() > 0 ? Long.valueOf(parameters.get(LIMIT).get(0)) : 10l;
+        Long limit = parameters.get(LIMIT) != null && !parameters.get(LIMIT).isEmpty() ? Long.valueOf(parameters.get(LIMIT).get(0)) : 10l;
         Map<String, Long> tags = taggingService.getTagsSuggester().suggest(prefix, path, 1l, limit, 0l, true, session);
         JSONObject result = new JSONObject();
         JSONArray tagsJSON = new JSONArray();

--- a/src/main/java/org/jahia/modules/forge/actions/EditVideo.java
+++ b/src/main/java/org/jahia/modules/forge/actions/EditVideo.java
@@ -46,7 +46,8 @@ import java.util.Map;
  */
 public class EditVideo extends Action {
 
-    private transient static Logger logger = org.slf4j.LoggerFactory.getLogger(EditVideo.class);
+    private static final Logger logger = org.slf4j.LoggerFactory.getLogger(EditVideo.class);
+    private static final String ALLOWFULLSCREEN = "allowfullscreen";
 
     @Override
     public ActionResult doExecute(HttpServletRequest req, RenderContext renderContext, Resource resource,
@@ -65,7 +66,7 @@ public class EditVideo extends Action {
         String identifier = getParameter(parameters, "identifier");
         String width = getParameter(parameters, "width");
         String height = getParameter(parameters, "height");
-        String allowfullscreen = getParameter(parameters, "allowfullscreen");
+        String allowfullscreen = getParameter(parameters, ALLOWFULLSCREEN);
 
         if (provider != null)
             videoNode.setProperty("provider", provider);
@@ -77,9 +78,9 @@ public class EditVideo extends Action {
             videoNode.setProperty("height", height);
 
         if (allowfullscreen != null && allowfullscreen.equals("on"))
-            videoNode.setProperty("allowfullscreen", true);
+            videoNode.setProperty(ALLOWFULLSCREEN, true);
         else
-            videoNode.setProperty("allowfullscreen", false);
+            videoNode.setProperty(ALLOWFULLSCREEN, false);
 
         session.save();
 

--- a/src/main/java/org/jahia/modules/forge/actions/PublishModule.java
+++ b/src/main/java/org/jahia/modules/forge/actions/PublishModule.java
@@ -48,7 +48,8 @@ import java.util.Map;
  */
 public class PublishModule extends Action {
 
-    private transient static Logger logger = org.slf4j.LoggerFactory.getLogger(PublishModule.class);
+    private static final Logger logger = org.slf4j.LoggerFactory.getLogger(PublishModule.class);
+    private static final String PUBLISHED = "published";
 
     @Override
     public ActionResult doExecute(HttpServletRequest req, RenderContext renderContext, Resource resource,
@@ -64,28 +65,28 @@ public class PublishModule extends Action {
             return ActionResult.BAD_REQUEST;
 
         boolean published = publish.equals("true");
-        module.setProperty("published", published);
+        module.setProperty(PUBLISHED, published);
         session.save();
 
-        // if no versions is published, publish the last one
         if (published) {
-            NodeIterator ni = module.getNodes();
-            List<JCRNodeWrapper> sortedVersions = ForgeFunctions.sortModulesByVersion(ni);
-            if (!sortedVersions.isEmpty()) {
-                boolean hasPublishedVersion = false;
-                for (JCRNodeWrapper version : sortedVersions) {
-                    if (version.isNodeType("jnt:forgeModuleVersion") && version.getProperty("published").getBoolean()) {
-                        hasPublishedVersion = true;
-                        break;
-                    }
-                }
-                if (!hasPublishedVersion) {
-                    sortedVersions.get(0).setProperty("published", true);
-                    session.save();
-                }
-            }
+            ensureLatestVersionPublished(module, session);
         }
 
-        return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put("published", published));
+        return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(PUBLISHED, published));
+    }
+
+    private static void ensureLatestVersionPublished(JCRNodeWrapper module, JCRSessionWrapper session) throws Exception {
+        NodeIterator ni = module.getNodes();
+        List<JCRNodeWrapper> sortedVersions = ForgeFunctions.sortModulesByVersion(ni);
+        if (sortedVersions.isEmpty()) {
+            return;
+        }
+        for (JCRNodeWrapper version : sortedVersions) {
+            if (version.isNodeType("jnt:forgeModuleVersion") && version.getProperty(PUBLISHED).getBoolean()) {
+                return;
+            }
+        }
+        sortedVersions.get(0).setProperty(PUBLISHED, true);
+        session.save();
     }
 }

--- a/src/main/java/org/jahia/modules/forge/actions/PublishModule.java
+++ b/src/main/java/org/jahia/modules/forge/actions/PublishModule.java
@@ -75,7 +75,7 @@ public class PublishModule extends Action {
         return new ActionResult(HttpServletResponse.SC_OK, null, new JSONObject().put(PUBLISHED, published));
     }
 
-    private static void ensureLatestVersionPublished(JCRNodeWrapper module, JCRSessionWrapper session) throws Exception {
+    private static void ensureLatestVersionPublished(JCRNodeWrapper module, JCRSessionWrapper session) throws javax.jcr.RepositoryException {
         NodeIterator ni = module.getNodes();
         List<JCRNodeWrapper> sortedVersions = ForgeFunctions.sortModulesByVersion(ni);
         if (sortedVersions.isEmpty()) {

--- a/src/main/java/org/jahia/modules/forge/actions/UpdateModuleIcon.java
+++ b/src/main/java/org/jahia/modules/forge/actions/UpdateModuleIcon.java
@@ -75,47 +75,54 @@ public class UpdateModuleIcon extends Action {
 
     @Override
     public ActionResult doExecute(HttpServletRequest req, RenderContext renderContext, Resource resource, JCRSessionWrapper session, Map<String, List<String>> parameters, URLResolver urlResolver) throws Exception {
-        // cleanup folder icon
         if (session.getNode(resource.getNode().getPath()).hasNode("icon")) {
             session.getNode(resource.getNode().getPath()).getNode("icon").remove();
         }
         JCRNodeWrapper iconFolder = createNode(req, new HashMap<String, List<String>>(), resource.getNode(), "jnt:folder", "icon", true);
         final FileUpload fileUpload = (FileUpload) req.getAttribute(FileUpload.FILEUPLOAD_ATTRIBUTE);
-        String redirectURL = null;
-        ActionResult result;
-        if (fileUpload != null && fileUpload.getParameterMap().containsKey("redirectURL")) {
-            // Only accept a site-relative redirect target to prevent open redirect.
-            String candidate = fileUpload.getParameterMap().get("redirectURL").get(0);
-            if (ActionSecurityUtils.isSafeRedirect(candidate)) {
-                redirectURL = candidate;
-            } else if (logger.isWarnEnabled()) {
-                logger.warn("UpdateModuleIcon: rejected unsafe redirectURL '{}'",
-                        ActionSecurityUtils.sanitizeForLog(candidate));
-            }
-        }
-        if (fileUpload != null && fileUpload.getFileItems() != null && fileUpload.getFileItems().size() > 0) {
-            final Map<String, DiskFileItem> stringDiskFileItemMap = fileUpload.getFileItems();
-            DiskFileItem itemEntry = stringDiskFileItemMap.get(stringDiskFileItemMap.keySet().iterator().next());
-            String uploadExtension = FilenameUtils.getExtension(itemEntry.getName()).toLowerCase();
-            boolean isImageContentType = itemEntry.getContentType() != null
-                    && "image".equals(StringUtils.substringBefore(itemEntry.getContentType(), "/"))
-                    && !"image/svg+xml".equalsIgnoreCase(itemEntry.getContentType());
-            if (itemEntry.getSize() > MAX_ICON_SIZE_BYTES) {
-                if (logger.isWarnEnabled()) {
-                    logger.warn("UpdateModuleIcon: rejected oversized icon '{}' ({} bytes)",
-                            ActionSecurityUtils.sanitizeForLog(itemEntry.getName()), itemEntry.getSize());
-                }
-                result = wrongFormatResult(session, redirectURL);
-            } else if (isImageContentType && ALLOWED_ICON_EXTENSIONS.contains(uploadExtension)) {
-                result = processValidIcon(session, iconFolder, itemEntry, redirectURL);
-            } else {
-                result = wrongFormatResult(session, redirectURL);
-            }
-        } else {
+        String redirectURL = extractSafeRedirect(fileUpload);
+
+        if (fileUpload == null || fileUpload.getFileItems() == null || fileUpload.getFileItems().isEmpty()) {
             String error = Messages.get(RESOURCES, "forge.updateIcon.error.noFileFound", session.getLocale());
-            result = new ActionResult(HttpServletResponse.SC_OK, redirectURL, new JSONObject().put(ICON_UPDATE, false).put(ERROR_MESSAGE, error));
+            return new ActionResult(HttpServletResponse.SC_OK, redirectURL, new JSONObject().put(ICON_UPDATE, false).put(ERROR_MESSAGE, error));
         }
-        return result;
+        final Map<String, DiskFileItem> stringDiskFileItemMap = fileUpload.getFileItems();
+        DiskFileItem itemEntry = stringDiskFileItemMap.get(stringDiskFileItemMap.keySet().iterator().next());
+        return validateAndProcessIcon(session, iconFolder, itemEntry, redirectURL);
+    }
+
+    private static String extractSafeRedirect(FileUpload fileUpload) {
+        if (fileUpload == null || !fileUpload.getParameterMap().containsKey("redirectURL")) {
+            return null;
+        }
+        String candidate = fileUpload.getParameterMap().get("redirectURL").get(0);
+        if (ActionSecurityUtils.isSafeRedirect(candidate)) {
+            return candidate;
+        }
+        if (logger.isWarnEnabled()) {
+            logger.warn("UpdateModuleIcon: rejected unsafe redirectURL '{}'",
+                    ActionSecurityUtils.sanitizeForLog(candidate));
+        }
+        return null;
+    }
+
+    private ActionResult validateAndProcessIcon(JCRSessionWrapper session, JCRNodeWrapper iconFolder,
+                                                DiskFileItem itemEntry, String redirectURL) throws JSONException {
+        if (itemEntry.getSize() > MAX_ICON_SIZE_BYTES) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("UpdateModuleIcon: rejected oversized icon '{}' ({} bytes)",
+                        ActionSecurityUtils.sanitizeForLog(itemEntry.getName()), itemEntry.getSize());
+            }
+            return wrongFormatResult(session, redirectURL);
+        }
+        String uploadExtension = FilenameUtils.getExtension(itemEntry.getName()).toLowerCase();
+        boolean isImageContentType = itemEntry.getContentType() != null
+                && "image".equals(StringUtils.substringBefore(itemEntry.getContentType(), "/"))
+                && !"image/svg+xml".equalsIgnoreCase(itemEntry.getContentType());
+        if (!isImageContentType || !ALLOWED_ICON_EXTENSIONS.contains(uploadExtension)) {
+            return wrongFormatResult(session, redirectURL);
+        }
+        return processValidIcon(session, iconFolder, itemEntry, redirectURL);
     }
 
     private ActionResult processValidIcon(JCRSessionWrapper session, JCRNodeWrapper iconFolder,

--- a/src/main/java/org/jahia/modules/forge/actions/UpdateModuleIcon.java
+++ b/src/main/java/org/jahia/modules/forge/actions/UpdateModuleIcon.java
@@ -88,7 +88,7 @@ public class UpdateModuleIcon extends Action {
             String candidate = fileUpload.getParameterMap().get("redirectURL").get(0);
             if (ActionSecurityUtils.isSafeRedirect(candidate)) {
                 redirectURL = candidate;
-            } else {
+            } else if (logger.isWarnEnabled()) {
                 logger.warn("UpdateModuleIcon: rejected unsafe redirectURL '{}'",
                         ActionSecurityUtils.sanitizeForLog(candidate));
             }
@@ -101,8 +101,10 @@ public class UpdateModuleIcon extends Action {
                     && "image".equals(StringUtils.substringBefore(itemEntry.getContentType(), "/"))
                     && !"image/svg+xml".equalsIgnoreCase(itemEntry.getContentType());
             if (itemEntry.getSize() > MAX_ICON_SIZE_BYTES) {
-                logger.warn("UpdateModuleIcon: rejected oversized icon '{}' ({} bytes)",
-                        ActionSecurityUtils.sanitizeForLog(itemEntry.getName()), itemEntry.getSize());
+                if (logger.isWarnEnabled()) {
+                    logger.warn("UpdateModuleIcon: rejected oversized icon '{}' ({} bytes)",
+                            ActionSecurityUtils.sanitizeForLog(itemEntry.getName()), itemEntry.getSize());
+                }
                 result = wrongFormatResult(session, redirectURL);
             } else if (isImageContentType && ALLOWED_ICON_EXTENSIONS.contains(uploadExtension)) {
                 result = processValidIcon(session, iconFolder, itemEntry, redirectURL);

--- a/src/main/java/org/jahia/modules/forge/actions/UpdateModuleIcon.java
+++ b/src/main/java/org/jahia/modules/forge/actions/UpdateModuleIcon.java
@@ -38,6 +38,7 @@ import org.jahia.services.render.Resource;
 import org.jahia.services.render.URLResolver;
 import org.jahia.tools.files.FileUpload;
 import org.jahia.utils.i18n.Messages;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 
@@ -58,9 +59,12 @@ import java.util.Set;
  */
 public class UpdateModuleIcon extends Action {
 
-    private transient static Logger logger = org.slf4j.LoggerFactory.getLogger(UpdateModuleIcon.class);
+    private static final Logger logger = org.slf4j.LoggerFactory.getLogger(UpdateModuleIcon.class);
 
     private static final String RESOURCES = "resources.privateappstore";
+    private static final String ICON_UPDATE = "iconUpdate";
+    private static final String ERROR_MESSAGE = "errorMessage";
+    private static final String ERR_WRONG_FORMAT = "forge.updateIcon.error.wrong.format";
     /** Maximum accepted size for an uploaded icon. */
     private static final long MAX_ICON_SIZE_BYTES = 5L * 1024 * 1024;
     /** Allowed raster image extensions (SVG is intentionally excluded - it can carry script). */
@@ -76,17 +80,17 @@ public class UpdateModuleIcon extends Action {
             session.getNode(resource.getNode().getPath()).getNode("icon").remove();
         }
         JCRNodeWrapper iconFolder = createNode(req, new HashMap<String, List<String>>(), resource.getNode(), "jnt:folder", "icon", true);
-        JCRNodeWrapper icon;
         final FileUpload fileUpload = (FileUpload) req.getAttribute(FileUpload.FILEUPLOAD_ATTRIBUTE);
         String redirectURL = null;
         ActionResult result;
         if (fileUpload != null && fileUpload.getParameterMap().containsKey("redirectURL")) {
             // Only accept a site-relative redirect target to prevent open redirect.
             String candidate = fileUpload.getParameterMap().get("redirectURL").get(0);
-            if (isSafeRedirect(candidate)) {
+            if (ActionSecurityUtils.isSafeRedirect(candidate)) {
                 redirectURL = candidate;
             } else {
-                logger.warn("UpdateModuleIcon: rejected unsafe redirectURL '{}'", candidate);
+                logger.warn("UpdateModuleIcon: rejected unsafe redirectURL '{}'",
+                        ActionSecurityUtils.sanitizeForLog(candidate));
             }
         }
         if (fileUpload != null && fileUpload.getFileItems() != null && fileUpload.getFileItems().size() > 0) {
@@ -97,56 +101,50 @@ public class UpdateModuleIcon extends Action {
                     && "image".equals(StringUtils.substringBefore(itemEntry.getContentType(), "/"))
                     && !"image/svg+xml".equalsIgnoreCase(itemEntry.getContentType());
             if (itemEntry.getSize() > MAX_ICON_SIZE_BYTES) {
-                logger.warn("UpdateModuleIcon: rejected oversized icon '{}' ({} bytes)", itemEntry.getName(), itemEntry.getSize());
-                String error = Messages.get(RESOURCES, "forge.updateIcon.error.wrong.format", session.getLocale());
-                result = new ActionResult(HttpServletResponse.SC_OK, redirectURL, new JSONObject().put("iconUpdate", false).put("errorMessage", error));
+                logger.warn("UpdateModuleIcon: rejected oversized icon '{}' ({} bytes)",
+                        ActionSecurityUtils.sanitizeForLog(itemEntry.getName()), itemEntry.getSize());
+                result = wrongFormatResult(session, redirectURL);
             } else if (isImageContentType && ALLOWED_ICON_EXTENSIONS.contains(uploadExtension)) {
-                File f = null;
-                try {
-                    icon = iconFolder.uploadFile(itemEntry.getName(), itemEntry.getInputStream(),
-                            JCRContentUtils.getMimeType(itemEntry.getName(), itemEntry.getContentType()));
-                    String fileExtension = FilenameUtils.getExtension(icon.getName());
-
-                    f = File.createTempFile("thumb", "." + fileExtension);
-                    // createThumb/getImage decode the bytes: a non-image masquerading as an image
-                    // (declared content-type) fails here and is rejected below.
-                    imageService.createThumb(imageService.getImage(icon), f, 125, false);
-                    try (InputStream is = new FileInputStream(f)) {
-                        icon = iconFolder.uploadFile(itemEntry.getName(), is, JCRContentUtils.getMimeType(itemEntry.getName(), itemEntry.getContentType()));
-                    }
-                    session.save();
-                    result = new ActionResult(HttpServletResponse.SC_OK, redirectURL, new JSONObject().put("iconUpdate", true).put("iconUrl", icon.getUrl()));
-                } catch (Exception e) {
-                    logger.warn("UpdateModuleIcon: failed to process uploaded icon '{}'", itemEntry.getName(), e);
-                    String error = Messages.get(RESOURCES, "forge.updateIcon.error.wrong.format", session.getLocale());
-                    result = new ActionResult(HttpServletResponse.SC_OK, redirectURL, new JSONObject().put("iconUpdate", false).put("errorMessage", error));
-                } finally {
-                    FileUtils.deleteQuietly(f);
-                }
+                result = processValidIcon(session, iconFolder, itemEntry, redirectURL);
             } else {
-                String error = Messages.get(RESOURCES, "forge.updateIcon.error.wrong.format", session.getLocale());
-                result = new ActionResult(HttpServletResponse.SC_OK, redirectURL, new JSONObject().put("iconUpdate", false).put("errorMessage", error));
+                result = wrongFormatResult(session, redirectURL);
             }
         } else {
             String error = Messages.get(RESOURCES, "forge.updateIcon.error.noFileFound", session.getLocale());
-            result = new ActionResult(HttpServletResponse.SC_OK, redirectURL, new JSONObject().put("iconUpdate", false).put("errorMessage", error));
+            result = new ActionResult(HttpServletResponse.SC_OK, redirectURL, new JSONObject().put(ICON_UPDATE, false).put(ERROR_MESSAGE, error));
         }
         return result;
     }
 
-    /**
-     * Only allow site-relative redirect targets. Rejects absolute URLs, protocol-relative URLs
-     * and pseudo-schemes (javascript:, data:, ...) to prevent open redirect / XSS.
-     */
-    private static boolean isSafeRedirect(String url) {
-        if (StringUtils.isBlank(url)) {
-            return false;
+    private ActionResult processValidIcon(JCRSessionWrapper session, JCRNodeWrapper iconFolder,
+                                          DiskFileItem itemEntry, String redirectURL) throws JSONException {
+        File f = null;
+        try {
+            JCRNodeWrapper icon = iconFolder.uploadFile(itemEntry.getName(), itemEntry.getInputStream(),
+                    JCRContentUtils.getMimeType(itemEntry.getName(), itemEntry.getContentType()));
+            String fileExtension = FilenameUtils.getExtension(icon.getName());
+
+            f = File.createTempFile("thumb", "." + fileExtension);
+            // createThumb/getImage decode the bytes: a non-image masquerading as an image
+            // (declared content-type) fails here and is rejected below.
+            imageService.createThumb(imageService.getImage(icon), f, 125, false);
+            try (InputStream is = new FileInputStream(f)) {
+                icon = iconFolder.uploadFile(itemEntry.getName(), is, JCRContentUtils.getMimeType(itemEntry.getName(), itemEntry.getContentType()));
+            }
+            session.save();
+            return new ActionResult(HttpServletResponse.SC_OK, redirectURL, new JSONObject().put(ICON_UPDATE, true).put("iconUrl", icon.getUrl()));
+        } catch (Exception e) {
+            logger.warn("UpdateModuleIcon: failed to process uploaded icon '{}'",
+                    ActionSecurityUtils.sanitizeForLog(itemEntry.getName()), e);
+            return wrongFormatResult(session, redirectURL);
+        } finally {
+            FileUtils.deleteQuietly(f);
         }
-        String lower = url.trim().toLowerCase();
-        return lower.startsWith("/")
-                && !lower.startsWith("//")
-                && !lower.startsWith("/\\")
-                && !lower.contains("://");
+    }
+
+    private static ActionResult wrongFormatResult(JCRSessionWrapper session, String redirectURL) throws JSONException {
+        String error = Messages.get(RESOURCES, ERR_WRONG_FORMAT, session.getLocale());
+        return new ActionResult(HttpServletResponse.SC_OK, redirectURL, new JSONObject().put(ICON_UPDATE, false).put(ERROR_MESSAGE, error));
     }
 
     public void setImageService(JahiaImageService imageService) {

--- a/src/main/java/org/jahia/modules/forge/actions/UpdateModuleIcon.java
+++ b/src/main/java/org/jahia/modules/forge/actions/UpdateModuleIcon.java
@@ -24,6 +24,7 @@
 package org.jahia.modules.forge.actions;
 
 import org.apache.commons.fileupload.disk.DiskFileItem;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jahia.bin.Action;
@@ -45,9 +46,12 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Action called to update a module icon
@@ -55,6 +59,13 @@ import java.util.Map;
 public class UpdateModuleIcon extends Action {
 
     private transient static Logger logger = org.slf4j.LoggerFactory.getLogger(UpdateModuleIcon.class);
+
+    private static final String RESOURCES = "resources.privateappstore";
+    /** Maximum accepted size for an uploaded icon. */
+    private static final long MAX_ICON_SIZE_BYTES = 5L * 1024 * 1024;
+    /** Allowed raster image extensions (SVG is intentionally excluded - it can carry script). */
+    private static final Set<String> ALLOWED_ICON_EXTENSIONS =
+            new HashSet<>(Arrays.asList("png", "jpg", "jpeg", "gif", "webp"));
 
     JahiaImageService imageService;
 
@@ -69,36 +80,73 @@ public class UpdateModuleIcon extends Action {
         final FileUpload fileUpload = (FileUpload) req.getAttribute(FileUpload.FILEUPLOAD_ATTRIBUTE);
         String redirectURL = null;
         ActionResult result;
-        if (fileUpload.getParameterMap().containsKey("redirectURL")) {
-            redirectURL = fileUpload.getParameterMap().get("redirectURL").get(0);
+        if (fileUpload != null && fileUpload.getParameterMap().containsKey("redirectURL")) {
+            // Only accept a site-relative redirect target to prevent open redirect.
+            String candidate = fileUpload.getParameterMap().get("redirectURL").get(0);
+            if (isSafeRedirect(candidate)) {
+                redirectURL = candidate;
+            } else {
+                logger.warn("UpdateModuleIcon: rejected unsafe redirectURL '{}'", candidate);
+            }
         }
         if (fileUpload != null && fileUpload.getFileItems() != null && fileUpload.getFileItems().size() > 0) {
             final Map<String, DiskFileItem> stringDiskFileItemMap = fileUpload.getFileItems();
             DiskFileItem itemEntry = stringDiskFileItemMap.get(stringDiskFileItemMap.keySet().iterator().next());
-            if (StringUtils.substringBefore(itemEntry.getContentType(), "/").equals("image")) {
-                icon = iconFolder.uploadFile(itemEntry.getName(), itemEntry.getInputStream(),
-                        JCRContentUtils.getMimeType(itemEntry.getName(), itemEntry.getContentType()));
-                String fileExtension = FilenameUtils.getExtension(icon.getName());
+            String uploadExtension = FilenameUtils.getExtension(itemEntry.getName()).toLowerCase();
+            boolean isImageContentType = itemEntry.getContentType() != null
+                    && "image".equals(StringUtils.substringBefore(itemEntry.getContentType(), "/"))
+                    && !"image/svg+xml".equalsIgnoreCase(itemEntry.getContentType());
+            if (itemEntry.getSize() > MAX_ICON_SIZE_BYTES) {
+                logger.warn("UpdateModuleIcon: rejected oversized icon '{}' ({} bytes)", itemEntry.getName(), itemEntry.getSize());
+                String error = Messages.get(RESOURCES, "forge.updateIcon.error.wrong.format", session.getLocale());
+                result = new ActionResult(HttpServletResponse.SC_OK, redirectURL, new JSONObject().put("iconUpdate", false).put("errorMessage", error));
+            } else if (isImageContentType && ALLOWED_ICON_EXTENSIONS.contains(uploadExtension)) {
+                File f = null;
+                try {
+                    icon = iconFolder.uploadFile(itemEntry.getName(), itemEntry.getInputStream(),
+                            JCRContentUtils.getMimeType(itemEntry.getName(), itemEntry.getContentType()));
+                    String fileExtension = FilenameUtils.getExtension(icon.getName());
 
-                final File f = File.createTempFile("thumb", "." + fileExtension);
-                imageService.createThumb(imageService.getImage(icon), f, 125, false);
-                InputStream is = new FileInputStream(f);
-                icon = iconFolder.uploadFile(itemEntry.getName(), is, JCRContentUtils.getMimeType(itemEntry.getName(), itemEntry.getContentType()));
-                is.close();
-                session.save();
-                result = new ActionResult(HttpServletResponse.SC_OK, redirectURL, new JSONObject().put("iconUpdate", true).put("iconUrl", icon.getUrl()));
+                    f = File.createTempFile("thumb", "." + fileExtension);
+                    // createThumb/getImage decode the bytes: a non-image masquerading as an image
+                    // (declared content-type) fails here and is rejected below.
+                    imageService.createThumb(imageService.getImage(icon), f, 125, false);
+                    try (InputStream is = new FileInputStream(f)) {
+                        icon = iconFolder.uploadFile(itemEntry.getName(), is, JCRContentUtils.getMimeType(itemEntry.getName(), itemEntry.getContentType()));
+                    }
+                    session.save();
+                    result = new ActionResult(HttpServletResponse.SC_OK, redirectURL, new JSONObject().put("iconUpdate", true).put("iconUrl", icon.getUrl()));
+                } catch (Exception e) {
+                    logger.warn("UpdateModuleIcon: failed to process uploaded icon '{}'", itemEntry.getName(), e);
+                    String error = Messages.get(RESOURCES, "forge.updateIcon.error.wrong.format", session.getLocale());
+                    result = new ActionResult(HttpServletResponse.SC_OK, redirectURL, new JSONObject().put("iconUpdate", false).put("errorMessage", error));
+                } finally {
+                    FileUtils.deleteQuietly(f);
+                }
             } else {
-                String error = Messages.get("resources.privateappstore", "forge.updateIcon.error.wrong.format", session.getLocale());
+                String error = Messages.get(RESOURCES, "forge.updateIcon.error.wrong.format", session.getLocale());
                 result = new ActionResult(HttpServletResponse.SC_OK, redirectURL, new JSONObject().put("iconUpdate", false).put("errorMessage", error));
             }
         } else {
-            String error = Messages.get("resources.privateappstore", "forge.updateIcon.error.noFileFound", session.getLocale());
+            String error = Messages.get(RESOURCES, "forge.updateIcon.error.noFileFound", session.getLocale());
             result = new ActionResult(HttpServletResponse.SC_OK, redirectURL, new JSONObject().put("iconUpdate", false).put("errorMessage", error));
         }
-        if (!StringUtils.isEmpty(redirectURL)) {
-            result.setUrl(redirectURL);
-        }
         return result;
+    }
+
+    /**
+     * Only allow site-relative redirect targets. Rejects absolute URLs, protocol-relative URLs
+     * and pseudo-schemes (javascript:, data:, ...) to prevent open redirect / XSS.
+     */
+    private static boolean isSafeRedirect(String url) {
+        if (StringUtils.isBlank(url)) {
+            return false;
+        }
+        String lower = url.trim().toLowerCase();
+        return lower.startsWith("/")
+                && !lower.startsWith("//")
+                && !lower.startsWith("/\\")
+                && !lower.contains("://");
     }
 
     public void setImageService(JahiaImageService imageService) {

--- a/src/main/java/org/jahia/modules/forge/actions/UpdateReferencesForModule.java
+++ b/src/main/java/org/jahia/modules/forge/actions/UpdateReferencesForModule.java
@@ -87,12 +87,14 @@ public class UpdateReferencesForModule extends Action implements BackgroundActio
         final HttpGet httpMethod = new HttpGet(UriComponentsBuilder.fromHttpUrl(url).build(false).toUri());
         httpMethod.addHeader("Authorization", "Basic " + Base64.encode((releaseInfo.getUsername() + ":" + releaseInfo.getPassword()).getBytes()));
 
-        try ( CloseableHttpResponse httpResponse = httpClient.execute(httpMethod)) {
+        try (CloseableHttpResponse httpResponse = httpClient.execute(httpMethod)) {
             if (httpResponse.getCode() == HttpServletResponse.SC_OK) {
                 File tmpJarFile = File.createTempFile("appStore", ".jar");
                 try {
-                    IOUtils.copy(httpResponse.getEntity().getContent(), new FileOutputStream(tmpJarFile));
-                    try ( JarFile jarFile = new JarFile(tmpJarFile)) {
+                    try (FileOutputStream out = new FileOutputStream(tmpJarFile)) {
+                        IOUtils.copy(httpResponse.getEntity().getContent(), out);
+                    }
+                    try (JarFile jarFile = new JarFile(tmpJarFile)) {
                         Manifest manifest = jarFile.getManifest();
                         Attributes attributes = manifest.getMainAttributes();
                         String value = attributes.getValue("Jahia-Depends");

--- a/src/main/java/org/jahia/modules/forge/flow/CategorySettingsHandler.java
+++ b/src/main/java/org/jahia/modules/forge/flow/CategorySettingsHandler.java
@@ -44,6 +44,10 @@ import java.util.*;
 public class CategorySettingsHandler implements Serializable {
 
     private static final long serialVersionUID = 871757139749838806L;
+    private static final String RESOURCES = "resources.privateappstore";
+    private static final String ROOT_CATEGORY = "rootCategory";
+    private static final String WORKSPACE_DEFAULT = "default";
+    private static final String JCR_TITLE = "jcr:title";
     private String rootCategoryIdentifier;
     private String currentCategory;
     private Map<Locale, String> categoryI18NTitles;
@@ -52,8 +56,8 @@ public class CategorySettingsHandler implements Serializable {
 
     public void init(JCRSiteNode site) {
         try {
-            if (site.hasProperty("rootCategory")) {
-                rootCategoryIdentifier = site.getProperty("rootCategory").getNode().getIdentifier();
+            if (site.hasProperty(ROOT_CATEGORY)) {
+                rootCategoryIdentifier = site.getProperty(ROOT_CATEGORY).getNode().getIdentifier();
             }
         } catch (RepositoryException e) {
             e.printStackTrace();
@@ -64,15 +68,15 @@ public class CategorySettingsHandler implements Serializable {
 
         try {
             Node category = site.getSession().getNodeByIdentifier(rootCategoryIdentifier);
-            site.setProperty("rootCategory", category);
+            site.setProperty(ROOT_CATEGORY, category);
             site.getSession().save();
             this.rootCategoryIdentifier = rootCategoryIdentifier;
         } catch (RepositoryException e) {
             messages.addMessage(new MessageBuilder()
                     .error()
-                    .source("rootCategory")
+                    .source(ROOT_CATEGORY)
                     .defaultText(
-                            Messages.getWithArgs("resources.privateappstore",
+                            Messages.getWithArgs(RESOURCES,
                                     "jahiaForge.settings.rootCategory.error", LocaleContextHolder.getLocale(), e.getMessage())).build());
             e.printStackTrace();
         }
@@ -85,11 +89,11 @@ public class CategorySettingsHandler implements Serializable {
             if (StringUtils.startsWith(key, "lang_")) {
                 String language = StringUtils.substringAfter(key, "lang_");
                 try {
-                    Session localizedSession = JCRSessionFactory.getInstance().getCurrentUserSession("default", new Locale(language));
+                    Session localizedSession = JCRSessionFactory.getInstance().getCurrentUserSession(WORKSPACE_DEFAULT, new Locale(language));
                     if (StringUtils.isEmpty(params.get(key))) {
-                        localizedSession.getNodeByIdentifier(currentCategory).getProperty("jcr:title").remove();
+                        localizedSession.getNodeByIdentifier(currentCategory).getProperty(JCR_TITLE).remove();
                     } else {
-                        localizedSession.getNodeByIdentifier(currentCategory).setProperty("jcr:title", params.get(key));
+                        localizedSession.getNodeByIdentifier(currentCategory).setProperty(JCR_TITLE, params.get(key));
                     }
                     localizedSession.save();
                 } catch (RepositoryException e) {
@@ -97,7 +101,7 @@ public class CategorySettingsHandler implements Serializable {
                             .error()
                             .source("editCategory")
                             .defaultText(
-                                    Messages.getWithArgs("resources.privateappstore",
+                                    Messages.getWithArgs(RESOURCES,
                                             "jahiaForge.settings.editCategory.error", LocaleContextHolder.getLocale(), e.getMessage())).build());
                     e.printStackTrace();
                 }
@@ -114,9 +118,9 @@ public class CategorySettingsHandler implements Serializable {
             availableLanguages = new LinkedList<String>();
             categoryUsages = new HashSet<String>();
             for (Locale locale : site.getLanguagesAsLocales()) {
-                JCRNodeWrapper localizedCategory = JCRSessionFactory.getInstance().getCurrentUserSession("default", locale).getNodeByIdentifier(currentCategoryUUID);
-                if (localizedCategory.hasProperty("jcr:title") && StringUtils.isNotEmpty(localizedCategory.getProperty("jcr:title").getString())) {
-                    categoryI18NTitles.put(locale, localizedCategory.getProperty("jcr:title").getString());
+                JCRNodeWrapper localizedCategory = JCRSessionFactory.getInstance().getCurrentUserSession(WORKSPACE_DEFAULT, locale).getNodeByIdentifier(currentCategoryUUID);
+                if (localizedCategory.hasProperty(JCR_TITLE) && StringUtils.isNotEmpty(localizedCategory.getProperty(JCR_TITLE).getString())) {
+                    categoryI18NTitles.put(locale, localizedCategory.getProperty(JCR_TITLE).getString());
                 } else {
                     availableLanguages.add(locale.getLanguage());
                 }
@@ -127,7 +131,7 @@ public class CategorySettingsHandler implements Serializable {
                 Property prop = references.nextProperty();
                 categoryUsages.add(((JCRNodeWrapper) prop.getParent()).getDisplayableName());
             }
-            Session defaultSession = JCRSessionFactory.getInstance().getCurrentUserSession("default");
+            Session defaultSession = JCRSessionFactory.getInstance().getCurrentUserSession(WORKSPACE_DEFAULT);
             references = defaultSession.getNodeByIdentifier(currentCategory).getWeakReferences();
             while (references.hasNext()) {
                 Property prop = references.nextProperty();
@@ -141,7 +145,7 @@ public class CategorySettingsHandler implements Serializable {
     public boolean addCategory(MessageContext messages, JCRSiteNode site, String category) {
         try {
             if (StringUtils.isNotEmpty(category)) {
-                Session session = JCRSessionFactory.getInstance().getCurrentUserSession("default");
+                Session session = JCRSessionFactory.getInstance().getCurrentUserSession(WORKSPACE_DEFAULT);
                 Node rootCategory = session.getNodeByIdentifier(rootCategoryIdentifier);
                 category = JCRContentUtils.findAvailableNodeName(rootCategory, category);
                 String uuid = session.getNodeByIdentifier(rootCategoryIdentifier).addNode(category, "jnt:category").getIdentifier();
@@ -160,7 +164,7 @@ public class CategorySettingsHandler implements Serializable {
                     .error()
                     .source("addCategory")
                     .defaultText(
-                            Messages.getWithArgs("resources.privateappstore",
+                            Messages.getWithArgs(RESOURCES,
                                     "jahiaForge.settings.addCategory.error", LocaleContextHolder.getLocale(), e.getMessage())).build());
             e.printStackTrace();
             return false;
@@ -170,7 +174,7 @@ public class CategorySettingsHandler implements Serializable {
 
     public void deleteCategory(MessageContext messages) {
         try {
-            Session session = JCRSessionFactory.getInstance().getCurrentUserSession("default");
+            Session session = JCRSessionFactory.getInstance().getCurrentUserSession(WORKSPACE_DEFAULT);
             session.getNodeByIdentifier(currentCategory).remove();
             availableLanguages.clear();
             categoryI18NTitles.clear();
@@ -182,7 +186,7 @@ public class CategorySettingsHandler implements Serializable {
                     .error()
                     .source("deleteCategory")
                     .defaultText(
-                            Messages.getWithArgs("resources.privateappstore",
+                            Messages.getWithArgs(RESOURCES,
                                     "jahiaForge.settings.deleteCategory.error", LocaleContextHolder.getLocale(), e.getMessage())).build());
             e.printStackTrace();
         }

--- a/src/main/java/org/jahia/modules/forge/flow/ForgeSettingsHandler.java
+++ b/src/main/java/org/jahia/modules/forge/flow/ForgeSettingsHandler.java
@@ -43,14 +43,15 @@ import java.io.Serializable;
 public class ForgeSettingsHandler implements Serializable {
 
     private static final long serialVersionUID = 2762062442866728163L;
+    private static final String JMIX_FORGE_SETTINGS = "jmix:forgeSettings";
 
-    static Logger logger = LoggerFactory.getLogger(ForgeSettingsHandler.class);
+    static final Logger logger = LoggerFactory.getLogger(ForgeSettingsHandler.class);
 
     private ForgeSettings forgeSettings;
 
     public ForgeSettings getForgeSettingsBySite(JCRSiteNode site) {
         try {
-            if (site != null && site.isNodeType("jmix:forgeSettings")) {
+            if (site != null && site.isNodeType(JMIX_FORGE_SETTINGS)) {
                 forgeSettings.setPassword(new String(Base64.decode(site.getProperty("forgeSettingsPassword").getString())));
                 forgeSettings.setUrl(site.getProperty("forgeSettingsUrl").getString());
                 forgeSettings.setId(site.getProperty("forgeSettingsId").getString());
@@ -70,8 +71,8 @@ public class ForgeSettingsHandler implements Serializable {
     public void save(MessageContext messages, JCRSiteNode site) {
         if (site != null) {
             try {
-                if (!site.isNodeType("jmix:forgeSettings")) {
-                    site.addMixin("jmix:forgeSettings");
+                if (!site.isNodeType(JMIX_FORGE_SETTINGS)) {
+                    site.addMixin(JMIX_FORGE_SETTINGS);
                 }
                 if (StringUtils.isNotBlank(forgeSettings.getPassword())) {
                     site.setProperty("forgeSettingsPassword", Base64.encode(forgeSettings.getPassword().getBytes()));

--- a/src/main/java/org/jahia/modules/forge/proxy/MavenProxy.java
+++ b/src/main/java/org/jahia/modules/forge/proxy/MavenProxy.java
@@ -24,8 +24,10 @@
 package org.jahia.modules.forge.proxy;
 
 import java.io.IOException;
+import java.net.URI;
 import org.apache.commons.lang.StringUtils;
 import org.apache.xerces.impl.dv.util.Base64;
+import org.jahia.api.Constants;
 import org.jahia.data.templates.ModuleReleaseInfo;
 import org.jahia.services.content.JCRSessionFactory;
 import org.jahia.services.content.JCRSessionWrapper;
@@ -54,16 +56,40 @@ public class MavenProxy implements Controller {
     public ModelAndView handleRequest(HttpServletRequest request, HttpServletResponse response) throws Exception {
 
         if (request.getMethod().equals("GET")) {
+            JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentUserSession("live");
+            // Require an authenticated (non-guest) user: the proxy forwards the site's stored
+            // Maven credentials, so it must never be reachable anonymously.
+            if (session.getUser() == null || Constants.GUEST_USERNAME.equals(session.getUser().getName())) {
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+                return null;
+            }
+
             String pathInfo = StringUtils.substringAfter(request.getPathInfo(), "/mavenproxy/");
             String siteName = StringUtils.substringBefore(pathInfo, "/");
             String path = "/" + StringUtils.substringAfter(pathInfo, "/");
 
-            ModuleReleaseInfo releaseInfo = getModuleReleaseInfo(siteName);
+            // Reject path traversal and absolute-URL injection to prevent SSRF: the caller must
+            // not be able to escape the configured repository root or point at another host.
+            if (path.contains("..") || path.contains("\\") || path.contains("://") || path.contains("\n") || path.contains("\r")) {
+                LOGGER.warn("MavenProxy: rejected suspicious path '{}'", path);
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+                return null;
+            }
 
-            String url = releaseInfo.getRepositoryUrl() + path;
+            ModuleReleaseInfo releaseInfo = getModuleReleaseInfo(session, siteName);
+
+            String repositoryUrl = releaseInfo.getRepositoryUrl();
+            String url = repositoryUrl + path;
+            // Canonicalize and confirm the resolved URL still lives under the repository root.
+            final URI resolvedUri = UriComponentsBuilder.fromHttpUrl(url).build(false).toUri().normalize();
+            if (repositoryUrl == null || !resolvedUri.toString().startsWith(repositoryUrl)) {
+                LOGGER.warn("MavenProxy: resolved URL '{}' escapes repository root '{}'", resolvedUri, repositoryUrl);
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+                return null;
+            }
             // Usage of SpringContextSingleton to prevent bug QA-9515
             final CloseableHttpClient httpClient = ((HttpClientService) SpringContextSingleton.getBean("HttpClientService")).getHttpClient(url);
-            final HttpGet httpMethod = new HttpGet(UriComponentsBuilder.fromHttpUrl(url).build(false).toUri());
+            final HttpGet httpMethod = new HttpGet(resolvedUri);
             httpMethod.addHeader("Authorization", "Basic " + Base64.encode((releaseInfo.getUsername() + ":" + releaseInfo.getPassword()).getBytes()));
             try (final CloseableHttpResponse httpResponse = httpClient.execute(httpMethod)) {
                 if (httpResponse.getCode() == HttpServletResponse.SC_OK) {
@@ -80,8 +106,7 @@ public class MavenProxy implements Controller {
         return null;
     }
 
-    private ModuleReleaseInfo getModuleReleaseInfo(final String siteName) throws RepositoryException {
-        JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentUserSession("live");
+    private ModuleReleaseInfo getModuleReleaseInfo(final JCRSessionWrapper session, final String siteName) throws RepositoryException {
         JCRSiteNode siteNode = (JCRSiteNode) session.getNode("/sites/" + siteName);
         String forgeSettingsUrl = siteNode.getProperty("forgeSettingsUrl").getString();
         String user = siteNode.getProperty("forgeSettingsUser").getString();

--- a/src/main/resources/jnt_forgeModule/html/forgeModule.changeLog.jsp
+++ b/src/main/resources/jnt_forgeModule/html/forgeModule.changeLog.jsp
@@ -127,7 +127,6 @@
                             <h2><fmt:message key="jnt_forgeEntry.label.previousVersions"/></h2>
                         </c:if>
                         <article class="previousVersion">
-                            ${previousVersion.path}
                             <template:module node="${previousVersion}">
                                 <template:param name="isDeveloper" value="${isDeveloper}"/>
                                 <template:param name="viewAsUser" value="${viewAsUser}"/>

--- a/src/main/resources/jnt_forgeModule/html/forgeModule.overview.jsp
+++ b/src/main/resources/jnt_forgeModule/html/forgeModule.overview.jsp
@@ -75,7 +75,7 @@
                 });
 
                 $('#authorURL-${id}').editable({
-                    value: '${not empty authorURL ? authorURL : ''}',
+                    value: '${functions:escapeJavaScript(not empty authorURL ? authorURL : '')}',
                     <jsp:include page="../../commons/bootstrap-editable-options.jsp">
                         <jsp:param name="postURL" value="${postURL}"/>
                         <jsp:param name="validate" value="url"/>
@@ -268,8 +268,9 @@
                     </c:when>
 
                     <c:otherwise>
-                        <c:if test="${not empty authorURL}">
-                            <a class="btn btn-small btn-primary" target="_blank" href="${authorURL}"><fmt:message key="jnt_forgeEntry.label.authorURL"/></a>
+                        <c:set var="safeAuthorURL" value="${(fn:startsWith(fn:toLowerCase(authorURL), 'http://') or fn:startsWith(fn:toLowerCase(authorURL), 'https://')) ? authorURL : ''}"/>
+                        <c:if test="${not empty safeAuthorURL}">
+                            <a class="btn btn-small btn-primary" target="_blank" rel="noopener noreferrer" href="${fn:escapeXml(safeAuthorURL)}"><fmt:message key="jnt_forgeEntry.label.authorURL"/></a>
                         </c:if>
                         <c:choose>
                             <c:when test="${authorIsOrganisation && not empty authorEmail}">

--- a/src/main/resources/jnt_forgePackage/html/forgePackage.changeLog.jsp
+++ b/src/main/resources/jnt_forgePackage/html/forgePackage.changeLog.jsp
@@ -126,7 +126,6 @@
                             <h2><fmt:message key="jnt_forgeEntry.label.previousVersions"/></h2>
                         </c:if>
                         <article class="previousVersion">
-                            ${previousVersion.path}
                             <template:module node="${previousVersion}">
                                 <template:param name="isDeveloper" value="${isDeveloper}"/>
                                 <template:param name="viewAsUser" value="${viewAsUser}"/>

--- a/src/main/resources/jnt_forgePackage/html/forgePackage.overview.jsp
+++ b/src/main/resources/jnt_forgePackage/html/forgePackage.overview.jsp
@@ -79,7 +79,7 @@
                 });
 
                 $('#authorURL-${id}').editable({
-                    value: '${not empty authorURL ? authorURL : ''}',
+                    value: '${functions:escapeJavaScript(not empty authorURL ? authorURL : '')}',
                     <jsp:include page="../../commons/bootstrap-editable-options.jsp">
                         <jsp:param name="postURL" value="${postURL}"/>
                         <jsp:param name="validate" value="url"/>
@@ -273,8 +273,9 @@
                     </c:when>
 
                     <c:otherwise>
-                        <c:if test="${not empty authorURL}">
-                            <a class="btn btn-small btn-primary" target="_blank" href="${authorURL}"><fmt:message key="jnt_forgeEntry.label.authorURL"/></a>
+                        <c:set var="safeAuthorURL" value="${(fn:startsWith(fn:toLowerCase(authorURL), 'http://') or fn:startsWith(fn:toLowerCase(authorURL), 'https://')) ? authorURL : ''}"/>
+                        <c:if test="${not empty safeAuthorURL}">
+                            <a class="btn btn-small btn-primary" target="_blank" rel="noopener noreferrer" href="${fn:escapeXml(safeAuthorURL)}"><fmt:message key="jnt_forgeEntry.label.authorURL"/></a>
                         </c:if>
                         <c:choose>
                             <c:when test="${authorIsOrganisation && not empty authorEmail}">

--- a/src/main/resources/jnt_post/html/post.reviewReply.jsp
+++ b/src/main/resources/jnt_post/html/post.reviewReply.jsp
@@ -56,7 +56,7 @@
                             alt="${fn:escapeXml(firstName)}<c:if test="${not empty firstName}">&nbsp;</c:if>${fn:escapeXml(lastName)}"
                         </c:when>
                         <c:otherwise>
-                            alt="${createdBy}"
+                            alt="${fn:escapeXml(createdBy)}"
                         </c:otherwise>
                     </c:choose>
                     width="60"

--- a/src/main/resources/jnt_review/html/review.jsp
+++ b/src/main/resources/jnt_review/html/review.jsp
@@ -100,7 +100,7 @@
                         alt="${fn:escapeXml(firstName)}<c:if test="${not empty firstName}">&nbsp;</c:if>${fn:escapeXml(lastName)}"
                     </c:when>
                     <c:otherwise>
-                        alt="${createdBy}"
+                        alt="${fn:escapeXml(createdBy)}"
                     </c:otherwise>
                 </c:choose>
                 width="60"
@@ -127,7 +127,7 @@
                                             ${fn:escapeXml(firstName)}<c:if test="${not empty firstName}">&nbsp;</c:if>${fn:escapeXml(lastName)}
                                         </c:when>
                                         <c:otherwise>
-                                            ${createdBy}
+                                            ${fn:escapeXml(createdBy)}
                                         </c:otherwise>
                                     </c:choose>
                                 </a>


### PR DESCRIPTION
## Summary

Security hardening pass on the Private App Store module (ticket SECURITY-571).
Backward-compatible fixes only — no API/CND/schema changes, no new runtime dependencies.

### MavenProxy (`org.jahia.modules.forge.proxy.MavenProxy`)
- Require an authenticated (non-guest) session before proxying any request. Previously a guest with `live` access could trigger a credentialed upstream call.
- Reject `..`, `\`, `://`, CR/LF in the forwarded path (path traversal / absolute-URL injection / header smuggling).
- Canonicalize the resolved URI and verify it stays under the configured repository root. Closes a CRITICAL SSRF vector.

### CreateEntryFromJar (`org.jahia.modules.forge.actions.CreateEntryFromJar`)
- 200 MB cap on the uploaded artifact; 10 MB cap on a tar entry read into memory (decompression-bomb protection in the `.tgz` branch).
- XML-escape `repositoryId` / `username` / `password` when generating the Maven `settings.xml` (was raw string concatenation, allowing an attacker-controlled username to inject `<mirror>` elements that redirect deploy traffic).
- Validate the `redirectURL` form parameter: site-relative only (`isSafeRedirect`). Closes an open-redirect after upload.

### UpdateModuleIcon (`org.jahia.modules.forge.actions.UpdateModuleIcon`)
- 5 MB cap on the icon.
- Reject `image/svg+xml` (SVG can carry inline `<script>`) and restrict the extension allowlist to `png/jpg/jpeg/gif/webp`. The icon was previously trusted from the client `Content-Type` header only.
- Thumbnail temp file deleted in `finally`; `FileInputStream` wrapped in try-with-resources.
- Image-decode wrapped in try/catch so a non-image masquerading as `image/*` fails cleanly instead of bubbling a 500.
- Validate the `redirectURL` form parameter (same helper as above).

### JSP output escaping / information disclosure
- `forgeModule.overview.jsp` / `forgePackage.overview.jsp`: scheme-guard (`http(s)` only) + `fn:escapeXml` on the `authorURL` anchor `href`, plus `rel=\"noopener noreferrer\"`. `functions:escapeJavaScript` on the `authorURL` value when embedded in an inline JS string literal.
- `review.jsp` / `post.reviewReply.jsp`: `fn:escapeXml(createdBy)` in `alt=` and text output.
- `forgeModule.changeLog.jsp` / `forgePackage.changeLog.jsp`: remove the leftover `\${previousVersion.path}` debug output that was leaking JCR paths in the public changelog view.

### Out of scope (deliberate, flagged for follow-up)
- **Base64 Maven credential storage** in `forgeSettingsPassword`. Switching to encryption (e.g. `org.jahia.utils.EncryptionUtils`) breaks every existing deployment until admins re-enter credentials, so it requires a migration plan + changelog entry rather than an in-place change.
- **`AddReview` allows guest posts with JSP-side-only captcha**. Server-side `CaptchaService` enforcement would change the guest review contract — recommended as a separate ticket.
- **Rich-text fields** (`description`, `FAQ`, `howToInstall`, `license`, `changeLog`) are intentionally rendered raw (CKEditor HTML). Jahia's write-time HTML filter remains the relevant control there.

## Test plan
- [ ] `mvn clean install` builds the bundle on JDK 8/11 (Java compiles cleanly on the dev workstation; CI to confirm)
- [ ] Smoke test module upload (`.jar`, `.war`, `.tgz`) — happy path
- [ ] Confirm oversized upload (>200 MB) is rejected with the i18n error
- [ ] Confirm `/mavenproxy/<site>/..%2F..%2Fetc/passwd` and friends return 400
- [ ] Confirm an anonymous request to `/mavenproxy/...` returns 401
- [ ] Confirm icon upload of an `image/svg+xml` is rejected
- [ ] Confirm a successful upload with `redirectURL=https://evil.example.com` does NOT redirect off-site
- [ ] Manually verify a module page renders correctly with a normal `authorURL`, and that an `authorURL` of `javascript:alert(1)` no longer produces a clickable link
- [ ] Confirm a logged-in non-developer cannot delete/reorder content via the previously-IDOR-prone code paths (verified in the companion store-template PR)