### PR TITLE
SECURITY-571 follow-ups: storefront E2E coverage + migration status normalization

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -26,7 +26,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Jahia/jahia-modules-action/static-analysis@v2
         with:
-          node_version: 12
+          # Match the Node the Maven build embeds (frontend-maven-plugin: v22.6.0);
+          # the dependency tree (normalize-package-data@7 via resolutions) needs Node >= 18.17.
+          node_version: 22
           auditci_level: critical
 
   build:

--- a/scripts/migrate-store-content.groovy
+++ b/scripts/migrate-store-content.groovy
@@ -92,7 +92,7 @@ def VERSION_TYPES     = ['jnt:forgeModuleVersion', 'jnt:forgePackageVersion'] as
 def MODULE_TYPES      = ['jnt:forgeModule', 'jnt:forgePackage'] as Set
 
 def report = new StringBuilder()
-def stats  = [modulesCopied: 0, modulesSkipped: 0, versionsRemapped: 0, urlsDropped: 0, reqVersionsCopied: 0, warnings: 0]
+def stats  = [modulesCopied: 0, modulesSkipped: 0, versionsRemapped: 0, urlsDropped: 0, reqVersionsCopied: 0, statusNormalized: 0, warnings: 0]
 def log    = { String msg -> report.append(msg).append('\n'); println msg }
 def warn   = { String msg -> stats.warnings++; log("  ! WARN: ${msg}") }
 
@@ -222,12 +222,20 @@ JCRTemplate.getInstance().doExecuteWithSystemSession(null, WORKSPACE, { JCRSessi
         }
     }
 
-    // ---- 3) fixup: requiredVersion re-point + drop stale url ------------
+    // ---- 3) fixup: requiredVersion re-point + drop stale url + normalize status ----
     // Walk the TARGET repo, map each version back to its SOURCE counterpart by
     // relative path, read the source's requiredVersion target NAME, and re-point
-    // to the target site's modules-required-versions node of that name.
-    log("\n[3] re-point requiredVersion + drop stale url")
+    // to the target site's modules-required-versions node of that name. Also lowercase
+    // each module's `status` to the choicelist key — 4.3.0 data may store it capitalized
+    // (e.g. "Community"), which the lowercase-keyed storefront status facet won't match.
+    log("\n[3] re-point requiredVersion + drop stale url + normalize status")
     if (!DRY_RUN) {
+        collect(tgtRepo, MODULE_TYPES, []).each { JCRNodeWrapper tm ->
+            if (tm.hasProperty('status')) {
+                String s = tm.getProperty('status').getString(), lc = s.toLowerCase()
+                if (s != lc) { tm.setProperty('status', lc); stats.statusNormalized++ }
+            }
+        }
         collect(tgtRepo, VERSION_TYPES, []).each { JCRNodeWrapper tv ->
             // drop stale generated-download url (5.0.0 builds it from maven coords)
             if (tv.hasProperty('url')) { tv.getProperty('url').remove(); stats.urlsDropped++ }
@@ -246,14 +254,17 @@ JCRTemplate.getInstance().doExecuteWithSystemSession(null, WORKSPACE, { JCRSessi
             tv.setProperty('requiredVersion', tgtReq.getNode(reqName))
             stats.versionsRemapped++
         }
-        log("  re-pointed ${stats.versionsRemapped} version(s); dropped ${stats.urlsDropped} stale url(s)")
+        log("  re-pointed ${stats.versionsRemapped} version(s); dropped ${stats.urlsDropped} stale url(s); normalized ${stats.statusNormalized} status value(s)")
     } else {
         // dry-run: just count what exists on the source
+        collect(srcRepo, MODULE_TYPES, []).each { JCRNodeWrapper sm ->
+            if (sm.hasProperty('status') && sm.getProperty('status').getString() != sm.getProperty('status').getString().toLowerCase()) stats.statusNormalized++
+        }
         collect(srcRepo, VERSION_TYPES, []).each { JCRNodeWrapper sv ->
             if (sv.hasProperty('url')) stats.urlsDropped++
             if (sv.hasProperty('requiredVersion')) stats.versionsRemapped++
         }
-        log("  would re-point ~${stats.versionsRemapped} version(s); would drop ~${stats.urlsDropped} stale url(s)")
+        log("  would re-point ~${stats.versionsRemapped} version(s); would drop ~${stats.urlsDropped} stale url(s); would normalize ~${stats.statusNormalized} status value(s)")
     }
 
     // ---- 4) forge settings (NOT migrated) ------------------------------
@@ -288,6 +299,7 @@ JCRTemplate.getInstance().doExecuteWithSystemSession(null, WORKSPACE, { JCRSessi
     log("  modules skipped (exist)  : ${stats.modulesSkipped}")
     log("  versions re-pointed      : ${stats.versionsRemapped}")
     log("  stale urls dropped       : ${stats.urlsDropped}")
+    log("  status values normalized : ${stats.statusNormalized}")
     log("  warnings                 : ${stats.warnings}")
     if (DRY_RUN) log("  (DRY-RUN — re-run with DRY_RUN = false to apply)")
     return null

--- a/tests/cypress/e2e/16-storefront.cy.ts
+++ b/tests/cypress/e2e/16-storefront.cy.ts
@@ -54,7 +54,7 @@ describe('Storefront read views (JS module)', () => {
         // The jahia-store-template import.xml seeds the home page (+ modules list),
         // the My-modules sub-page and contents/modules-repository.
         createSite(siteKey, {
-            languages: 'en',
+            languages: 'en,fr',
             templateSet: 'jahia-store-template',
             serverName: 'storefront.local',
             locale: 'en'
@@ -216,6 +216,17 @@ describe('Storefront read views (JS module)', () => {
             .and('not.contain', 'moduleList.rss');
         // Social links are icon-only (brand glyphs); the platform name is the accessible label.
         cy.get('footer [aria-label="Facebook"]').find('svg').should('exist');
+    });
+
+    it('shows a language selector (current marked, other links to that language)', () => {
+        // The site is en,fr — the header language selector lists both, marks the current one,
+        // and each link points the current page at that language (Jahia /<lang>/ render).
+        cy.visit(homeRender);
+        cy.get('header [aria-label="Language"]', {timeout: 20000}).within(() => {
+            cy.contains('a', 'EN').should('have.attr', 'aria-current', 'true');
+            cy.contains('a', 'FR').should('not.have.attr', 'aria-current');
+            cy.contains('a', 'FR').should('have.attr', 'href').and('include', '/fr/');
+        });
     });
 
     it('signs in via the header login form (posts to /cms/login)', () => {

--- a/tests/cypress/e2e/16-storefront.cy.ts
+++ b/tests/cypress/e2e/16-storefront.cy.ts
@@ -214,6 +214,8 @@ describe('Storefront read views (JS module)', () => {
             .should('have.attr', 'href')
             .and('match', /\/feed$/)
             .and('not.contain', 'moduleList.rss');
+        // Social links are icon-only (brand glyphs); the platform name is the accessible label.
+        cy.get('footer [aria-label="Facebook"]').find('svg').should('exist');
     });
 
     it('signs in via the header login form (posts to /cms/login)', () => {
@@ -223,7 +225,9 @@ describe('Storefront read views (JS module)', () => {
         cy.logout();
         cy.visit(`/cms/render/live/en/sites/${siteKey}/home.html`);
         // Open the login panel (the toggle button), then fill + submit the form.
-        cy.contains('button', /log in/i).click();
+        // Wait for the login island to hydrate (data-login-ready) before clicking the
+        // SSR trigger, else the panel-toggle handler may not be wired yet.
+        cy.contains('button[data-login-ready="true"]', /log in/i, {timeout: 20000}).click();
         cy.get('#login-username').type('root');
         cy.get('#login-password').type(`${Cypress.env('SUPER_USER_PASSWORD')}{enter}`);
         // A successful form login redirects back to the page, now authenticated:
@@ -236,7 +240,9 @@ describe('Storefront read views (JS module)', () => {
         publishAndWaitJobEnding(`/sites/${siteKey}`, ['en']);
         cy.logout();
         cy.visit(`/cms/render/live/en/sites/${siteKey}/home.html`);
-        cy.contains('button', /log in/i).click();
+        // Wait for the login island to hydrate (data-login-ready) before clicking the
+        // SSR trigger, else the panel-toggle handler may not be wired yet.
+        cy.contains('button[data-login-ready="true"]', /log in/i, {timeout: 20000}).click();
         cy.get('#login-username').type('root');
         cy.get('#login-password').type('definitely-not-the-password{enter}');
         // Jahia redirects back to the page with ?loginError=…; the login island surfaces an

--- a/tests/cypress/e2e/16-storefront.cy.ts
+++ b/tests/cypress/e2e/16-storefront.cy.ts
@@ -227,6 +227,21 @@ describe('Storefront read views (JS module)', () => {
         cy.contains('root').should('be.visible');
     });
 
+    it('shows an inline error on bad credentials (no /cms/login dead-end)', () => {
+        publishAndWaitJobEnding(`/sites/${siteKey}`, ['en']);
+        cy.logout();
+        cy.visit(`/cms/render/live/en/sites/${siteKey}/home.html`);
+        cy.contains('button', /log in/i).click();
+        cy.get('#login-username').type('root');
+        cy.get('#login-password').type('definitely-not-the-password{enter}');
+        // Jahia redirects back to the page with ?loginError=…; the login island surfaces an
+        // inline message and reopens the form instead of stranding the user on /cms/login.
+        cy.contains(/invalid username or password/i, {timeout: 20000}).should('be.visible');
+        cy.location('pathname').should('not.contain', '/cms/login');
+        // The error param is stripped from the URL so a refresh is clean.
+        cy.location('search').should('not.contain', 'loginError');
+    });
+
     it('gates the "My modules" nav entry by login + Store role', () => {
         cy.login();
         publishAndWaitJobEnding(`/sites/${siteKey}`, ['en']);

--- a/tests/cypress/e2e/16-storefront.cy.ts
+++ b/tests/cypress/e2e/16-storefront.cy.ts
@@ -115,7 +115,11 @@ describe('Storefront read views (JS module)', () => {
         cy.contains('Draft Module').should('not.exist');
     });
 
-    it('filters the grid by status (server-side facet)', () => {
+    it('filters the grid by status (server-side facet, case-insensitive)', () => {
+        // Store the status capitalized, as migrated 4.3.0 data can be ("Supported"), while the
+        // facet submits the lowercase choicelist key ("supported"): matching must be
+        // case-insensitive. Restored to lowercase afterwards for the later tests.
+        setNodeProperty(`${repo}/analytics`, 'status', 'Supported', 'en');
         cy.visit(homeRender);
         // Server-side filtering: check a Status facet and submit the GET form; the page
         // reloads showing only matching modules (non-matching are absent, not just hidden).
@@ -123,6 +127,7 @@ describe('Storefront read views (JS module)', () => {
         cy.get('[data-forge-filter] button[type="submit"]').click();
         cy.contains('[data-forge-card]', 'Analytics Dashboard').should('be.visible');
         cy.contains('[data-forge-card]', 'SEO Toolkit').should('not.exist');
+        setNodeProperty(`${repo}/analytics`, 'status', 'supported', 'en');
     });
 
     it('filters the grid by text (server-side)', () => {

--- a/tests/cypress/e2e/20-accessibility.cy.ts
+++ b/tests/cypress/e2e/20-accessibility.cy.ts
@@ -78,7 +78,7 @@ describe('Accessibility — WCAG 2.2 AAA gate (JS module)', () => {
         }
 
         createSite(siteKey, {
-            languages: 'en',
+            languages: 'en,fr',
             templateSet: 'jahia-store-template',
             serverName: 'a11y.local',
             locale: 'en'


### PR DESCRIPTION
## Summary

Follow-up to #27 — these commits were completed and verified on the migration branch but had not been pushed when #27 was merged. Companion to Jahia/store-template#11 (the fixes these tests cover).

- **fix(migration): normalize module status to the lowercase choicelist key** — the step-3 fixup of `migrate-store-content.groovy` lowercases any capitalized `status` value (4.3.0 data stores `Community`; the 5.0.0 facet uses lowercase keys), with a dry-run count and a `status values normalized` summary line. Re-running the script reprocesses already-migrated content.
- **test: status facet matches a capitalized stored value** — stores `Supported`, filters `supported`, asserts the match (proves `LOWER(e.[status])` works despite `indexed=no`).
- **test: bad credentials show an inline error** — asserts the `role=alert` message renders on the same page instead of redirecting to `/cms/login`.
- **test: wait for login hydration** — both login tests gate on `button[data-login-ready="true"]`, removing a pre-existing flake where Cypress clicked the SSR trigger before the island hydrated.
- **test: bilingual sites + header language selector** — specs 16/20 sites now use `languages: 'en,fr'`; asserts EN is `aria-current="true"` and the FR link targets `/fr/`; the selector is included in the axe AAA audit.

## Test plan

- [x] `16-storefront.cy.ts` 14/14 against a local Jahia 8.2.4
- [x] `17-authoring.cy.ts` green
- [x] `20-accessibility.cy.ts` 3/3 (WCAG 2.2 AAA)