### PR TITLE
Potential fix for code scanning alert no. 10: Failure to use HTTPS or SFTP URL in Maven artifact upload/download

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <pluginRepository>
             <id>jahiaRepository</id>
             <name>Jahia's Maven Repository</name>
-            <url>http://maven.jahia.org/maven2</url>
+            <url>https://maven.jahia.org/maven2</url>
         </pluginRepository>
     </pluginRepositories>
     <dependencies>


### PR DESCRIPTION
Potential fix for [https://github.com/Jahia/privateappstore/security/code-scanning/10](https://github.com/Jahia/privateappstore/security/code-scanning/10)

The general fix is to ensure all Maven repository endpoints used for dependency/plugin download or upload use secure transport (`https://` or `sftp://`), never `http://` or `ftp://`.

In this file, the best minimal, non-functional-change fix is to update the plugin repository URL in `pom.xml` under `<pluginRepositories><pluginRepository>` from HTTP to HTTPS, keeping the same host and path:
- Change line 84 from `http://maven.jahia.org/maven2` to `https://maven.jahia.org/maven2`.

No additional methods, definitions, or imports are required in a Maven POM for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
