### PR TITLE
SECURITY-571: remediate CodeQL alerts (path-injection, non-https Maven URL)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,13 +77,6 @@
             <url>https://devtools.jahia.com/nexus/content/groups/public</url>
         </repository>
     </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>jahiaRepository</id>
-            <name>Jahia's Maven Repository</name>
-            <url>http://maven.jahia.org/maven2</url>
-        </pluginRepository>
-    </pluginRepositories>
     <dependencies>
         <dependency>
             <groupId>atg.taglib.json</groupId>

--- a/src/main/java/org/jahia/modules/forge/actions/CreateEntryFromJar.java
+++ b/src/main/java/org/jahia/modules/forge/actions/CreateEntryFromJar.java
@@ -123,6 +123,10 @@ public class CreateEntryFromJar extends Action {
     private static final String ERR_MISSING_MANIFEST_ATTRIBUTE = "forge.uploadJar.error.missing.manifest.attribute";
     private static final String ERR_VERSION_NUMBER = "forge.uploadJar.error.versionNumber";
     private static final String LOG_UNSAFE_REDIRECT = "CreateEntryFromJar: rejected unsafe redirectURL '{}'";
+    /** Allowed upload extensions. Downstream code only ever sees these constants, never user input. */
+    private static final String EXTENSION_JAR = "jar";
+    private static final String EXTENSION_WAR = "war";
+    private static final String EXTENSION_TGZ = "tgz";
     /** Maximum accepted size for an uploaded artifact (guards against resource-exhaustion uploads). */
     private static final long MAX_UPLOAD_SIZE_BYTES = 200L * 1024 * 1024;
     /** Maximum size of a single tar entry we read into memory (guards against decompression bombs). */
@@ -176,12 +180,12 @@ public class CreateEntryFromJar extends Action {
         if (StringUtils.contains(filename, "SNAPSHOT.")) {
             return errorResult(session, "forge.uploadJar.error.snapshot.not.allowed");
         }
-        String extension = StringUtils.substringAfterLast(filename, ".");
-        if (!(StringUtils.equals(extension, "jar") || StringUtils.equals(extension, "war") || StringUtils.equals(extension, "tgz"))) {
+        String extension = trustedExtension(filename);
+        if (extension == null) {
             return errorResult(session, "forge.uploadJar.error.wrong.format");
         }
         Map<String, List<String>> formParameters = fu.getParameterMap();
-        if (extension.endsWith("tgz")) {
+        if (EXTENSION_TGZ.equals(extension)) {
             return handleTgzUpload(uploadedFile, request, renderContext, resource, session, formParameters);
         }
         return handleJarUpload(uploadedFile, extension, request, renderContext, resource, session, formParameters);
@@ -447,6 +451,26 @@ public class CreateEntryFromJar extends Action {
         } finally {
             FileUtils.deleteQuietly(artifact);
         }
+    }
+
+    /**
+     * Allow-lists the uploaded file extension and returns the matching {@code EXTENSION_*} constant,
+     * or {@code null} when the extension is not supported. The returned value is always a constant —
+     * never the user-derived string — so the suffix later embedded in the temp-artifact path
+     * ({@code File.createTempFile}) is provably untainted (CodeQL java/path-injection).
+     */
+    private static String trustedExtension(String filename) {
+        String extension = StringUtils.substringAfterLast(filename, ".");
+        if (StringUtils.equals(extension, EXTENSION_JAR)) {
+            return EXTENSION_JAR;
+        }
+        if (StringUtils.equals(extension, EXTENSION_WAR)) {
+            return EXTENSION_WAR;
+        }
+        if (StringUtils.equals(extension, EXTENSION_TGZ)) {
+            return EXTENSION_TGZ;
+        }
+        return null;
     }
 
     private static ActionResult errorResult(JCRSessionWrapper session, String messageKey) throws JSONException {


### PR DESCRIPTION
Remediates the three open CodeQL code-scanning alerts on `master`.

## Changes

### `java/path-injection` — alerts #11 and #12 (`CreateEntryFromJar.java`)
The file extension derived from the user-controlled upload filename flowed into `File.createTempFile("artifact", "." + extension)` and the subsequent temp-artifact file operations. **Not exploitable** — the extension was already strictly allow-listed (exact `StringUtils.equals` match on `jar`/`war`/`tgz`) — but CodeQL's taint engine doesn't recognize `StringUtils.equals` as a sanitizer guard.

Fix: `trustedExtension()` maps the validated extension to the `EXTENSION_JAR`/`EXTENSION_WAR`/`EXTENSION_TGZ` string-literal constants and returns `null` otherwise. Downstream code only ever sees a constant, never the user-derived string, severing the taint flow at its single source (clears both sinks at once). Behavior is unchanged for every input: case-sensitive exact match; empty, dotless, and null filenames still rejected; `a.tar.gz` still rejected.

### `java/maven/non-https-url` — alert #10 (`pom.xml`)
Removed the `<pluginRepositories>` block pointing at `http://maven.jahia.org/maven2`. Maven ≥ 3.8.1 blocks `external:http:*` through its default mirror, so nothing has resolved from this repository in any modern build — plugins and the parent pom resolve from the https devtools.jahia.com public group. Removing the dead block is safer than rewriting it to https on a possibly-dead host.

## Test plan
- [x] `mvn clean package` — BUILD SUCCESS on the exact resulting tree
- [x] Independent Java review pass — behavioral equivalence confirmed for all edge cases (`module.JAR`, `a.tar.gz`, dotless/null filenames); no Java <16 source-level violations
- [x] No change to the upload contract (`createEntryFromJar` action) or `moduleList.json`