### PR TITLE
test(storefront): assert the status facets render in alphabetical order

### DIFF
--- a/tests/cypress/e2e/16-storefront.cy.ts
+++ b/tests/cypress/e2e/16-storefront.cy.ts
@@ -129,6 +129,14 @@ describe('Storefront read views (JS module)', () => {
         setNodeProperty(`${repo}/analytics`, 'status', 'supported', 'en');
     });
 
+    it('lists the status facets in alphabetical order', () => {
+        cy.visit(homeRender);
+        // The left-rail Status facet is sorted alphabetically to ease scanning.
+        cy.get('[data-forge-filter] input[name="status"]', {timeout: 20000})
+            .then($els => $els.toArray().map(el => el.value))
+            .should('deep.equal', ['community', 'labs', 'legacy', 'supported']);
+    });
+
     it('shows a loading indicator while applying a filter', () => {
         cy.visit(homeRender);
         // The bar is global header chrome, hidden until a filter/search/pagination navigation starts.


### PR DESCRIPTION
## Test: status facets render alphabetically

Companion to **Jahia/store-template#16**. Adds a Cypress assertion that the left-rail **Status** facet is ordered alphabetically (`community, labs, legacy, supported`).

(The category facet isn't seeded in this spec — no root category is configured — so category ordering is covered by the store-template change itself, not here.)

### Test plan
- [x] `16-storefront` **22/22**, `20-accessibility` (WCAG 2.2 AAA) **3/3** against dockerized Jahia 8.2 + Nexus with the companion `store-template` branch deployed
- [x] tests-repo ESLint (`--max-warnings 1`) clean
