### PR TITLE
fix(security): close residual path/injection gaps in upload and role-query paths

### DIFF
--- a/src/main/java/org/jahia/modules/forge/actions/CreateEntryFromJar.java
+++ b/src/main/java/org/jahia/modules/forge/actions/CreateEntryFromJar.java
@@ -258,7 +258,8 @@ public class CreateEntryFromJar extends Action {
         final String reqVersionAttribute = jahiaJsonObject.getString("required-version");
         final String requiredVersion = VERSION_PREFIX + reqVersionAttribute;
         if (StringUtils.isEmpty(moduleName) || StringUtils.isEmpty(groupId)
-                || StringUtils.isEmpty(reqVersionAttribute) || !isSafeCoordinate(groupId, moduleName)) {
+                || StringUtils.isEmpty(reqVersionAttribute) || !isSafeCoordinate(groupId, moduleName)
+                || !isSafeRequiredVersion(reqVersionAttribute)) {
             return errorResult(session, ERR_MISSING_MANIFEST_ATTRIBUTE);
         }
         final JCRNodeWrapper versions = getJahiaVersion(requiredVersion, resource, session);
@@ -306,7 +307,7 @@ public class CreateEntryFromJar extends Action {
         String reqVersionAttribute = attributes.getValue("Jahia-Required-Version");
         final String requiredVersion = VERSION_PREFIX + reqVersionAttribute;
         if (StringUtils.isEmpty(packageName) || StringUtils.isEmpty(reqVersionAttribute) || StringUtils.isEmpty(version)
-                || !isSafePackageName(packageName)) {
+                || !isSafePackageName(packageName) || !isSafeRequiredVersion(reqVersionAttribute)) {
             return errorResult(session, ERR_MISSING_MANIFEST_ATTRIBUTE);
         }
         JCRNodeWrapper versions = getJahiaVersion(requiredVersion, resource, session);
@@ -397,7 +398,8 @@ public class CreateEntryFromJar extends Action {
         String reqVersionAttribute = attributes.getValue("Jahia-Required-Version");
         final String requiredVersion = VERSION_PREFIX + reqVersionAttribute;
         if (StringUtils.isEmpty(moduleName) || StringUtils.isEmpty(groupId)
-                || StringUtils.isEmpty(reqVersionAttribute) || !isSafeCoordinate(groupId, moduleName)) {
+                || StringUtils.isEmpty(reqVersionAttribute) || !isSafeCoordinate(groupId, moduleName)
+                || !isSafeRequiredVersion(reqVersionAttribute)) {
             return errorResult(session, ERR_MISSING_MANIFEST_ATTRIBUTE);
         }
         JCRNodeWrapper versions = getJahiaVersion(requiredVersion, resource, session);
@@ -519,8 +521,16 @@ public class CreateEntryFromJar extends Action {
      * remain valid — only parent-traversal and path escapes are rejected (SECURITY-571).
      */
     private static boolean isSafeCoordinate(String groupId, String moduleName) {
-        return !groupId.contains("..") && !groupId.contains("\\")
-                && !moduleName.contains("..") && !moduleName.contains("\\");
+        return isSafePathFragment(groupId) && isSafePathFragment(moduleName);
+    }
+
+    /**
+     * True when {@code value} cannot escape or deepen the JCR relative path it is spliced into:
+     * no ".." parent-traversal, no "\\" or "/" path separator (a "/" in an addNode relative path
+     * silently creates extra nested children — SECURITY-571).
+     */
+    private static boolean isSafePathFragment(String value) {
+        return value != null && !value.contains("..") && !value.contains("\\") && !value.contains("/");
     }
 
     /**
@@ -530,12 +540,22 @@ public class CreateEntryFromJar extends Action {
      * {@link #isSafeCoordinate} guard the module and JS upload paths already apply.
      */
     private static boolean isSafePackageName(String name) {
-        return name != null && !name.contains("..") && !name.contains("/") && !name.contains("\\");
+        return isSafePathFragment(name);
     }
 
     /** True when {@code value} is a plain Maven coordinate token (no expression / option metacharacters). */
     private static boolean isSafeMavenCoordinate(String value) {
         return value != null && SAFE_MAVEN_COORD.matcher(value).matches();
+    }
+
+    /**
+     * True when the archive-supplied required-version is a plain version token. It is concatenated
+     * into the {@code version-<x>} JCR node name and navigated/created under
+     * {@code …/modules-required-versions}; restricting it to the Maven-coordinate charset keeps a
+     * crafted value (e.g. {@code 8.2/../../x}) from traversing the JCR tree (SECURITY-571).
+     */
+    private static boolean isSafeRequiredVersion(String value) {
+        return isSafeMavenCoordinate(value);
     }
 
     /** Outcome of preparing a module node for a new version: the module + an optional conflict error. */

--- a/src/main/java/org/jahia/modules/forge/graphql/ManageRolesQueryExtension.java
+++ b/src/main/java/org/jahia/modules/forge/graphql/ManageRolesQueryExtension.java
@@ -56,6 +56,7 @@ public final class ManageRolesQueryExtension {
     @GraphQLDescription("Read the role-management settings for a site")
     public static GqlManageRolesSettings getManageRolesSettings(
             @GraphQLName("siteKey") @GraphQLNonNull final String siteKey) {
+        ForgeSettingsMutationExtension.validateSiteKey(siteKey);
         try {
             return JCRTemplate.getInstance().doExecuteWithSystemSession(session ->
                     readManageRolesSettings(session, siteKey));
@@ -137,6 +138,7 @@ public final class ManageRolesQueryExtension {
             @GraphQLName("siteKey") @GraphQLNonNull final String siteKey,
             @GraphQLName("searchTerm") @GraphQLNonNull final String searchTerm,
             @GraphQLName("type") @GraphQLNonNull final PrincipalType type) {
+        ForgeSettingsMutationExtension.validateSiteKey(siteKey);
         if (StringUtils.isBlank(searchTerm)) {
             return Collections.emptyList();
         }

--- a/src/main/resources/jnt_contentFolder/rss/contentFolder.moduleList.jsp
+++ b/src/main/resources/jnt_contentFolder/rss/contentFolder.moduleList.jsp
@@ -42,10 +42,10 @@
                         </c:otherwise>
                     </c:choose>
                 <item>
-                    <title>${version.name}, ${version.properties['versionNumber']}</title>
+                    <title>${fn:escapeXml(version.name)}, ${fn:escapeXml(version.properties['versionNumber'].string)}</title>
                     <link>${fn:escapeXml(downloadUrl)}</link>
                     <guid>${fn:escapeXml(downloadUrl)}</guid>
-                    <description>${version.displayableName}, version ${version.properties['versionNumber']}.</description>
+                    <description>${fn:escapeXml(version.displayableName)}, version ${fn:escapeXml(version.properties['versionNumber'].string)}.</description>
                         <jcr:nodeProperty node="${version}" name="jcr:lastModified" var="modified"/>
                     <pubDate><fmt:formatDate value="${modified.time}" pattern="EEE, dd MMM yyyy HH:mm:ss Z" /></pubDate>
                 </item>


### PR DESCRIPTION
## Summary

Security-hardening pass on `jahia-store`, driven by a fresh audit. Closes residual path/injection gaps on author-supplied (semi-trusted) archive metadata and a GraphQL entry point. Builds green; **full Cypress E2E 102/102**.

## Changes (`7c03e93`)

- **`CreateEntryFromJar.isSafeCoordinate`** now also rejects `/`: a `/` in `groupId`/`moduleName` was spliced into a JCR `addNode` relative path, silently creating nested children and polluting the catalog tree. Extracted the shared check as `isSafePathFragment` (`isSafePackageName` delegates).
- **Required-version validation**: the archive `required-version` attribute is validated against the Maven-coordinate charset before it becomes a `version-<x>` JCR node name navigated/created under `modules-required-versions` — a crafted value (`8.2/../../x`) could traverse the tree. Applied to all three upload paths (JS, JAR, package).
- **`ManageRolesQueryExtension`**: call `validateSiteKey()` first in `manageRolesSettings` and `searchForgePrincipals`, matching every other forge GraphQL entry point (the siteKey was concatenated into JCR paths / an `ISDESCENDANTNODE` literal without the path-traversal guard).
- **RSS `moduleList` feed**: XML-escape the version name, displayable name and version number in `<title>`/`<description>` (only `<link>`/`<guid>` were escaped), closing a stored XML-injection via crafted version metadata.

## Deliberately not changed

- Base64-obfuscated Nexus password — already a documented accepted risk with a "move to a real secret store" follow-up; not a code-path vuln.
- Icon `nosniff` header — icons are served by Jahia's core `/files/` servlet, not this module; a module-registered filter on `/files/**` would be over-broad. The companion store-template PR's raster-only MIME allowlist shrinks the upload surface; the proper fix is platform-level.

## Test plan

- [x] `mvn clean install` green (compile + OSGi bundle + import.zip)
- [x] Full Cypress E2E suite: **102/102 passing, 0 failures** across all 20 specs (upload, publish, download, role admin, storefront, authoring, richtext, accessibility)

Companion PR: store-template security hardening (same branch name).


---
Companion PR: https://github.com/Jahia/store-template/pull/17
