### PR TITLE
test(security): JUnit validator tests + negative E2E coverage; harden '..' site key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,19 @@
             <version>3.4.0</version>
             <scope>provided</scope>
         </dependency>
+        <!-- Unit tests for the pure security/validation logic (no Jahia container needed). -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.25.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/org/jahia/modules/forge/actions/CreateEntryFromJar.java
+++ b/src/main/java/org/jahia/modules/forge/actions/CreateEntryFromJar.java
@@ -461,7 +461,8 @@ public class CreateEntryFromJar extends Action {
      * never the user-derived string — so the suffix later embedded in the temp-artifact path
      * ({@code File.createTempFile}) is provably untainted (CodeQL java/path-injection).
      */
-    private static String trustedExtension(String filename) {
+    // package-private for unit testing
+    static String trustedExtension(String filename) {
         String extension = StringUtils.substringAfterLast(filename, ".");
         if (StringUtils.equals(extension, EXTENSION_JAR)) {
             return EXTENSION_JAR;
@@ -520,7 +521,7 @@ public class CreateEntryFromJar extends Action {
      * could escape the modules repository. Dotted groupIds and scoped (@scope/name) module names
      * remain valid — only parent-traversal and path escapes are rejected (SECURITY-571).
      */
-    private static boolean isSafeCoordinate(String groupId, String moduleName) {
+    static boolean isSafeCoordinate(String groupId, String moduleName) {
         return isSafePathFragment(groupId) && isSafePathFragment(moduleName);
     }
 
@@ -529,7 +530,7 @@ public class CreateEntryFromJar extends Action {
      * no ".." parent-traversal, no "\\" or "/" path separator (a "/" in an addNode relative path
      * silently creates extra nested children — SECURITY-571).
      */
-    private static boolean isSafePathFragment(String value) {
+    static boolean isSafePathFragment(String value) {
         return value != null && !value.contains("..") && !value.contains("\\") && !value.contains("/");
     }
 
@@ -539,12 +540,12 @@ public class CreateEntryFromJar extends Action {
      * identifier, so any "/", "\\" or ".." segment is illegal (SECURITY-571). Mirrors the
      * {@link #isSafeCoordinate} guard the module and JS upload paths already apply.
      */
-    private static boolean isSafePackageName(String name) {
+    static boolean isSafePackageName(String name) {
         return isSafePathFragment(name);
     }
 
     /** True when {@code value} is a plain Maven coordinate token (no expression / option metacharacters). */
-    private static boolean isSafeMavenCoordinate(String value) {
+    static boolean isSafeMavenCoordinate(String value) {
         return value != null && SAFE_MAVEN_COORD.matcher(value).matches();
     }
 
@@ -554,7 +555,7 @@ public class CreateEntryFromJar extends Action {
      * {@code …/modules-required-versions}; restricting it to the Maven-coordinate charset keeps a
      * crafted value (e.g. {@code 8.2/../../x}) from traversing the JCR tree (SECURITY-571).
      */
-    private static boolean isSafeRequiredVersion(String value) {
+    static boolean isSafeRequiredVersion(String value) {
         return isSafeMavenCoordinate(value);
     }
 

--- a/src/main/java/org/jahia/modules/forge/graphql/ForgeSettingsMutationExtension.java
+++ b/src/main/java/org/jahia/modules/forge/graphql/ForgeSettingsMutationExtension.java
@@ -99,7 +99,9 @@ public final class ForgeSettingsMutationExtension {
      * (e.g. "../.." resolving to "/"). Mirrors {@code MavenProxy.isValidSiteName} (SECURITY-571).
      */
     static void validateSiteKey(String siteKey) {
-        if (siteKey == null || !SAFE_SITE_KEY.matcher(siteKey).matches()) {
+        // The charset permits dots, so also reject ".." explicitly: a pure-traversal key like
+        // ".." would otherwise match the pattern and resolve "/sites/.." to "/".
+        if (siteKey == null || !SAFE_SITE_KEY.matcher(siteKey).matches() || siteKey.contains("..")) {
             throw new ForgeSettingsException("Invalid site key: " + siteKey, null);
         }
     }

--- a/src/main/java/org/jahia/modules/forge/proxy/MavenProxy.java
+++ b/src/main/java/org/jahia/modules/forge/proxy/MavenProxy.java
@@ -178,7 +178,7 @@ public class MavenProxy extends HttpServlet {
         }
     }
 
-    private static boolean isSuspicious(String path) {
+    static boolean isSuspicious(String path) {
         // Block raw AND percent-encoded traversal / scheme-injection sequences. The proxy now
         // serves anonymous callers on public stores, so harden the SSRF guard against encoded
         // variants regardless of how the downstream URI builder normalizes them. Legitimate
@@ -189,9 +189,11 @@ public class MavenProxy extends HttpServlet {
                 || p.contains("%2e") || p.contains("%2f") || p.contains("%5c");
     }
 
-    /** A site key is a simple identifier; reject anything that could alter the JCR path. */
-    private static boolean isValidSiteName(String siteName) {
-        return StringUtils.isNotBlank(siteName) && siteName.matches("[A-Za-z0-9._-]+");
+    /** A site key is a simple identifier; reject anything that could alter the JCR path. The
+     *  charset permits dots, so ".." is rejected explicitly (it would otherwise match the pattern). */
+    static boolean isValidSiteName(String siteName) {
+        return StringUtils.isNotBlank(siteName) && siteName.matches("[A-Za-z0-9._-]+")
+                && !siteName.contains("..");
     }
 
     /**

--- a/src/main/java/org/jahia/modules/forge/settings/ForgeSettingsServiceImpl.java
+++ b/src/main/java/org/jahia/modules/forge/settings/ForgeSettingsServiceImpl.java
@@ -166,7 +166,7 @@ public class ForgeSettingsServiceImpl implements ForgeSettingsService {
     }
 
     /** Escape the value half of an LDAP/OSGi filter assertion. */
-    private static String escape(String value) {
+    static String escape(String value) {
         return value.replace("\\", "\\5c").replace("*", "\\2a")
                 .replace("(", "\\28").replace(")", "\\29");
     }

--- a/src/test/java/org/jahia/modules/forge/actions/ActionSecurityUtilsTest.java
+++ b/src/test/java/org/jahia/modules/forge/actions/ActionSecurityUtilsTest.java
@@ -1,0 +1,71 @@
+package org.jahia.modules.forge.actions;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ActionSecurityUtils} — the open-redirect guard and the log-forging
+ * sanitizer used by the upload action. Pure logic, no Jahia container required.
+ */
+class ActionSecurityUtilsTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/home.html", "/sites/store/contents/x.html", "/ok", "/a/b/c"})
+    @DisplayName("isSafeRedirect accepts site-relative paths")
+    void isSafeRedirect_acceptsRelative(String url) {
+        assertThat(ActionSecurityUtils.isSafeRedirect(url)).isTrue();
+    }
+
+    @Test
+    @DisplayName("isSafeRedirect trims leading whitespace before judging")
+    void isSafeRedirect_trimsWhitespace() {
+        assertThat(ActionSecurityUtils.isSafeRedirect("   /ok")).isTrue();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {
+            "   ",
+            "//evil.com",
+            "/\\evil.com",
+            "http://evil.com",
+            "HTTPS://evil.com",
+            "javascript:alert(1)",
+            "data:text/html,x",
+            "/path://escape"
+    })
+    @DisplayName("isSafeRedirect rejects absolute, protocol-relative and pseudo-scheme URLs")
+    void isSafeRedirect_rejectsUnsafe(String url) {
+        assertThat(ActionSecurityUtils.isSafeRedirect(url)).isFalse();
+    }
+
+    @Test
+    @DisplayName("sanitizeForLog returns the literal \"null\" for null input")
+    void sanitizeForLog_null() {
+        assertThat(ActionSecurityUtils.sanitizeForLog(null)).isEqualTo("null");
+    }
+
+    @Test
+    @DisplayName("sanitizeForLog strips CR/LF and control characters that could forge a log line")
+    void sanitizeForLog_stripsControlChars() {
+        assertThat(ActionSecurityUtils.sanitizeForLog("line1\r\nFAKE LOG ENTRY")).isEqualTo("line1__FAKE LOG ENTRY");
+        assertThat(ActionSecurityUtils.sanitizeForLog("a\tb")).isEqualTo("a_b");
+        assertThat(ActionSecurityUtils.sanitizeForLog("plain text")).isEqualTo("plain text");
+    }
+
+    @Test
+    @DisplayName("sanitizeForLog truncates to 200 chars + ellipsis")
+    void sanitizeForLog_truncates() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 250; i++) {
+            sb.append('x');
+        }
+        String result = ActionSecurityUtils.sanitizeForLog(sb.toString());
+        assertThat(result).hasSize(203).endsWith("...");
+    }
+}

--- a/src/test/java/org/jahia/modules/forge/actions/CreateEntryFromJarValidatorTest.java
+++ b/src/test/java/org/jahia/modules/forge/actions/CreateEntryFromJarValidatorTest.java
@@ -1,0 +1,112 @@
+package org.jahia.modules.forge.actions;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the path/coordinate validators in {@link CreateEntryFromJar} — the SECURITY-571
+ * guards that keep author-supplied archive metadata (groupId, module/package name, required
+ * version, file extension) from traversing the JCR tree or smuggling a tainted file extension into
+ * the temp-artifact path. Pure logic, no Jahia container required.
+ */
+class CreateEntryFromJarValidatorTest {
+
+    // --- isSafePathFragment / isSafeCoordinate / isSafePackageName -------------------------------
+
+    @ParameterizedTest
+    @ValueSource(strings = {"org.jahia", "my-module", "com.example_foo", "1.0", "modules"})
+    @DisplayName("isSafePathFragment accepts plain coordinate tokens")
+    void isSafePathFragment_accepts_plainTokens(String value) {
+        assertThat(CreateEntryFromJar.isSafePathFragment(value)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"..", "a..b", "../etc", "a/b", "a\\b", "/abs", "x\\..\\y"})
+    @DisplayName("isSafePathFragment rejects traversal / path-separator values")
+    void isSafePathFragment_rejects_traversalAndSeparators(String value) {
+        assertThat(CreateEntryFromJar.isSafePathFragment(value)).isFalse();
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @DisplayName("isSafePathFragment rejects null")
+    void isSafePathFragment_rejects_null(String value) {
+        assertThat(CreateEntryFromJar.isSafePathFragment(value)).isFalse();
+    }
+
+    @Test
+    @DisplayName("isSafeCoordinate requires BOTH groupId and moduleName to be safe")
+    void isSafeCoordinate_requiresBothSafe() {
+        assertThat(CreateEntryFromJar.isSafeCoordinate("org.jahia.modules", "my-module")).isTrue();
+        assertThat(CreateEntryFromJar.isSafeCoordinate("..", "my-module")).isFalse();
+        assertThat(CreateEntryFromJar.isSafeCoordinate("org.jahia", "a/b")).isFalse();
+        assertThat(CreateEntryFromJar.isSafeCoordinate("org.jahia", "a\\b")).isFalse();
+    }
+
+    @Test
+    @DisplayName("isSafePackageName rejects separators and traversal")
+    void isSafePackageName_rejectsSeparators() {
+        assertThat(CreateEntryFromJar.isSafePackageName("my-package")).isTrue();
+        assertThat(CreateEntryFromJar.isSafePackageName("a/b")).isFalse();
+        assertThat(CreateEntryFromJar.isSafePackageName("a..b")).isFalse();
+        assertThat(CreateEntryFromJar.isSafePackageName(null)).isFalse();
+    }
+
+    // --- isSafeMavenCoordinate / isSafeRequiredVersion ------------------------------------------
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1.0.0", "8.1.6.2", "1.0-SNAPSHOT", "8.2", "RELEASE_1"})
+    @DisplayName("isSafeMavenCoordinate accepts the Maven token charset")
+    void isSafeMavenCoordinate_accepts(String value) {
+        assertThat(CreateEntryFromJar.isSafeMavenCoordinate(value)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"8.2/../../x", "1.0 beta", "a;b", "$(whoami)", "a/b", "x\ny"})
+    @DisplayName("isSafeMavenCoordinate rejects separators, whitespace and shell/expression metacharacters")
+    void isSafeMavenCoordinate_rejects(String value) {
+        assertThat(CreateEntryFromJar.isSafeMavenCoordinate(value)).isFalse();
+    }
+
+    @Test
+    @DisplayName("isSafeMavenCoordinate rejects null and empty (requires at least one char)")
+    void isSafeMavenCoordinate_rejectsNullAndEmpty() {
+        assertThat(CreateEntryFromJar.isSafeMavenCoordinate(null)).isFalse();
+        assertThat(CreateEntryFromJar.isSafeMavenCoordinate("")).isFalse();
+    }
+
+    @Test
+    @DisplayName("isSafeRequiredVersion blocks a crafted required-version from traversing the JCR tree")
+    void isSafeRequiredVersion_blocksTraversal() {
+        assertThat(CreateEntryFromJar.isSafeRequiredVersion("8.1.6.2")).isTrue();
+        assertThat(CreateEntryFromJar.isSafeRequiredVersion("8.2/../../x")).isFalse();
+        assertThat(CreateEntryFromJar.isSafeRequiredVersion("8.2\\..\\x")).isFalse();
+    }
+
+    // --- trustedExtension -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("trustedExtension returns a constant for jar/tgz and null for everything else")
+    void trustedExtension_allowlist() {
+        assertThat(CreateEntryFromJar.trustedExtension("module.jar")).isEqualTo("jar");
+        assertThat(CreateEntryFromJar.trustedExtension("package.tgz")).isEqualTo("tgz");
+        assertThat(CreateEntryFromJar.trustedExtension("evil.war")).isNull();
+        assertThat(CreateEntryFromJar.trustedExtension("module.jar.exe")).isNull();
+        assertThat(CreateEntryFromJar.trustedExtension("noextension")).isNull();
+        assertThat(CreateEntryFromJar.trustedExtension(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("trustedExtension never echoes the user-supplied extension back")
+    void trustedExtension_neverReturnsUserInput() {
+        String result = CreateEntryFromJar.trustedExtension("payload.sh");
+        assertThat(result).isNull();
+        // For an accepted extension the returned value is the interned constant, not the input slice.
+        assertThat(CreateEntryFromJar.trustedExtension("a.JAR")).isNull(); // case-sensitive: only lowercase jar
+    }
+}

--- a/src/test/java/org/jahia/modules/forge/graphql/ForgeSettingsMutationExtensionTest.java
+++ b/src/test/java/org/jahia/modules/forge/graphql/ForgeSettingsMutationExtensionTest.java
@@ -1,0 +1,35 @@
+package org.jahia.modules.forge.graphql;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link ForgeSettingsMutationExtension#validateSiteKey(String)} — the guard every
+ * forge GraphQL entry point calls before concatenating a siteKey into a JCR site path, so a
+ * traversal value can't sidestep the permission gate. Pure logic, no Jahia container required.
+ */
+class ForgeSettingsMutationExtensionTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"store", "private-app-store", "my.site_01", "A1"})
+    @DisplayName("validateSiteKey accepts a simple identifier")
+    void validateSiteKey_acceptsIdentifier(String siteKey) {
+        assertThatCode(() -> ForgeSettingsMutationExtension.validateSiteKey(siteKey))
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", "..", "../..", "foo/bar", "foo bar", "a\\b", "site:evil"})
+    @DisplayName("validateSiteKey rejects null, blank and path-altering values")
+    void validateSiteKey_rejectsUnsafe(String siteKey) {
+        assertThatThrownBy(() -> ForgeSettingsMutationExtension.validateSiteKey(siteKey))
+                .isInstanceOf(RuntimeException.class);
+    }
+}

--- a/src/test/java/org/jahia/modules/forge/proxy/MavenProxyValidatorTest.java
+++ b/src/test/java/org/jahia/modules/forge/proxy/MavenProxyValidatorTest.java
@@ -1,0 +1,57 @@
+package org.jahia.modules.forge.proxy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the {@link MavenProxy} SSRF / path-traversal guards. The proxy now serves
+ * anonymous callers on public stores, so {@code isSuspicious} must block raw AND percent-encoded
+ * traversal/scheme-injection, and {@code isValidSiteName} must reject anything that could alter the
+ * JCR path. Pure logic, no Jahia container required.
+ */
+class MavenProxyValidatorTest {
+
+    @Test
+    @DisplayName("isSuspicious passes a legitimate Maven coordinate path")
+    void isSuspicious_passesLegitPath() {
+        assertThat(MavenProxy.isSuspicious("org/jahia/modules/my-module/1.0.0/my-module-1.0.0.jar")).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "../../etc/passwd",
+            "a\\b",
+            "http://169.254.169.254/latest/meta-data",
+            "file:///etc/passwd",
+            "a\nb",
+            "a\rb",
+            "%2e%2e/x",
+            "%2E%2E/x",          // uppercase: lowercased before the check
+            "x%2fy",
+            "x%5cy"
+    })
+    @DisplayName("isSuspicious blocks raw and percent-encoded traversal / scheme injection (case-insensitive)")
+    void isSuspicious_blocksTraversalAndSchemes(String path) {
+        assertThat(MavenProxy.isSuspicious(path)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"store", "my-site_01", "private.app.store", "A1"})
+    @DisplayName("isValidSiteName accepts simple identifiers")
+    void isValidSiteName_acceptsIdentifiers(String name) {
+        assertThat(MavenProxy.isValidSiteName(name)).isTrue();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   ", "..", "x..y", "../etc", "foo/bar", "foo bar", "a\\b", "site:evil"})
+    @DisplayName("isValidSiteName rejects blanks and anything that could alter the JCR path")
+    void isValidSiteName_rejectsUnsafe(String name) {
+        assertThat(MavenProxy.isValidSiteName(name)).isFalse();
+    }
+}

--- a/src/test/java/org/jahia/modules/forge/settings/ForgeSettingsServiceImplTest.java
+++ b/src/test/java/org/jahia/modules/forge/settings/ForgeSettingsServiceImplTest.java
@@ -1,0 +1,39 @@
+package org.jahia.modules.forge.settings;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ForgeSettingsServiceImpl#escape(String)} — the LDAP/OSGi filter-assertion
+ * escaper that keeps an attacker-influenced siteKey from injecting into the configuration filter
+ * {@code (&(service.factoryPid=...)(siteKey=<value>))}. Pure logic, no OSGi runtime required.
+ */
+class ForgeSettingsServiceImplTest {
+
+    @Test
+    @DisplayName("escape leaves a plain value untouched")
+    void escape_plain() {
+        assertThat(ForgeSettingsServiceImpl.escape("my-store")).isEqualTo("my-store");
+    }
+
+    @Test
+    @DisplayName("escape encodes each RFC 4515 special character")
+    void escape_specialChars() {
+        assertThat(ForgeSettingsServiceImpl.escape("*")).isEqualTo("\\2a");
+        assertThat(ForgeSettingsServiceImpl.escape("(")).isEqualTo("\\28");
+        assertThat(ForgeSettingsServiceImpl.escape(")")).isEqualTo("\\29");
+        assertThat(ForgeSettingsServiceImpl.escape("\\")).isEqualTo("\\5c");
+    }
+
+    @Test
+    @DisplayName("escape neutralises a filter-injection attempt and escapes backslash FIRST")
+    void escape_injectionAttempt() {
+        // A crafted wildcard/paren payload must not survive as filter syntax.
+        assertThat(ForgeSettingsServiceImpl.escape("*)(uid=*"))
+                .isEqualTo("\\2a\\29\\28uid=\\2a");
+        // Backslash is escaped before the others so its own escape is not re-escaped.
+        assertThat(ForgeSettingsServiceImpl.escape("\\*")).isEqualTo("\\5c\\2a");
+    }
+}

--- a/tests/cypress/e2e/14-moduleListAndDownload.cy.ts
+++ b/tests/cypress/e2e/14-moduleListAndDownload.cy.ts
@@ -282,4 +282,30 @@ describe('Module list JSON + download', () => {
             expect(module, 'unpublished module hidden from listing').to.be.undefined;
         });
     });
+
+    it('rejects a bad site name and never serves a traversal / scheme-injection path on the mavenproxy', () => {
+        // The SSRF + site-name guard (isValidSiteName) runs before any auth, so this is checked
+        // anonymously. A site name the servlet container does not normalise away (a space / colon)
+        // reaches the app guard and is rejected with 400.
+        const base = '/modules/mavenproxy';
+        [`${base}/bad%20site/org/x/1.0/x-1.0.jar`, `${base}/foo:evil/org/x/1.0/x-1.0.jar`].forEach(url => {
+            cy.request({url, failOnStatusCode: false}).then(res => {
+                expect(res.status, url).to.equal(400);
+            });
+        });
+
+        // Traversal / encoded-separator / scheme-injection paths must never serve an artifact:
+        // they are blocked either by the servlet guard (400) or normalised/rejected by the
+        // container (404/400) — in every case a 4xx, never a 200. (isSuspicious itself is covered
+        // directly by MavenProxyValidatorTest at the unit level.)
+        [
+            `${base}/${siteKey}/org/jahia/%2e%2e/%2e%2e/etc`,
+            `${base}/${siteKey}/a/b%5cc/1.0/a-1.0.jar`,
+            `${base}/${siteKey}/x/http%3a%2f%2fevil/1.0/x.jar`
+        ].forEach(url => {
+            cy.request({url, failOnStatusCode: false}).then(res => {
+                expect(res.status, url).to.be.gte(400);
+            });
+        });
+    });
 });

--- a/tests/cypress/e2e/16-storefront.cy.ts
+++ b/tests/cypress/e2e/16-storefront.cy.ts
@@ -148,8 +148,8 @@ describe('Storefront read views (JS module)', () => {
         });
         cy.get('[data-forge-filter] input[name="status"][value="community"]').check();
         cy.get('[data-nav-progress]').should('have.attr', 'data-loading');
-        // The accessible status region announces loading.
-        cy.get('[role="status"]').should('contain.text', 'Loading');
+        // The accessible status region (an <output>, implicit role=status) announces loading.
+        cy.get('[data-nav-status]').should('contain.text', 'Loading');
     });
 
     it('filters the grid by status in a non-default language (French)', () => {

--- a/tests/cypress/e2e/17-authoring.cy.ts
+++ b/tests/cypress/e2e/17-authoring.cy.ts
@@ -32,6 +32,21 @@ const openVersionsPopup = (): void => {
 };
 
 /**
+ * Open the module editor and switch to its Media tab, where the screenshot and
+ * video managers live. Scope the tab click to the editor tablist ("Module
+ * fields") since the detail page also has a "Module sections" tablist. Waits for
+ * the screenshot manager to hydrate.
+ */
+const openEditorMediaTab = (): void => {
+    // Wait for the editor island to hydrate before clicking (the SSR button is
+    // visible before its handler attaches).
+    cy.get('[data-editor-ready]', {timeout: 20000});
+    cy.contains('button', /edit module/i).click();
+    cy.get('[aria-label="Module fields"]', {timeout: 20000}).contains('[role="tab"]', 'Media').click();
+    cy.get('[data-screenshots-ready]', {timeout: 20000});
+};
+
+/**
  * Authoring views (jahia-store-template JS module) — Phase 3.
  *
  * Covers in-site editing of module metadata via the ModuleEditor island, which
@@ -50,6 +65,23 @@ describe('Authoring views (JS module)', () => {
 
     const addNodeWithProps: DocumentNode =
         require('graphql-tag/loader!../fixtures/graphql/mutation/addNodeWithProperties.graphql');
+
+    const getNodeProperty: DocumentNode =
+        require('graphql-tag/loader!../fixtures/graphql/query/getNodeProperties.graphql');
+
+    // Category-settings fixtures (same OSGi-backed path the admin UI uses), to verify
+    // the editor lists the configured categories.
+    const addNode: DocumentNode =
+        require('graphql-tag/loader!../fixtures/graphql/mutation/addNodeForTest.graphql');
+
+    const setRootCategory: DocumentNode =
+        require('graphql-tag/loader!../fixtures/graphql/mutation/setRootCategory.graphql');
+
+    const addForgeCategory: DocumentNode =
+        require('graphql-tag/loader!../fixtures/graphql/mutation/addForgeCategory.graphql');
+
+    const readProp = (path: string, name: string) =>
+        cy.apollo({query: getNodeProperty, variables: {path, name, language: null}, fetchPolicy: 'no-cache'});
 
     const islandBundle = '/modules/jahia-store-template/dist/client/components/forge/ModuleEditor.client.tsx.js';
 
@@ -326,14 +358,14 @@ describe('Authoring views (JS module)', () => {
         cy.get('body').should($b => expect($b.html()).to.contain('createEntryFromJar.do'));
     });
 
-    it('owner can reorder and delete screenshots (jcr mutations)', () => {
+    it('owner can reorder and delete screenshots in the editor Media tab (jcr mutations)', () => {
         // Two screenshots in the module's (autocreated) screenshots node.
         uploadFile('../../assets/screenshot.png', `${repo}/widget/screenshots`, 'shot-a.png', 'image/png');
         uploadFile('../../assets/screenshot.png', `${repo}/widget/screenshots`, 'shot-b.png', 'image/png');
 
         cy.intercept('POST', '/modules/graphql').as('gql');
         cy.visit(moduleRender);
-        cy.get('[data-screenshots-ready]', {timeout: 20000});
+        openEditorMediaTab();
         cy.get('[data-screenshot-name]').then($els => {
             expect($els.eq(0).attr('data-screenshot-name')).to.eq('shot-a.png');
             expect($els.eq(1).attr('data-screenshot-name')).to.eq('shot-b.png');
@@ -343,7 +375,7 @@ describe('Authoring views (JS module)', () => {
         cy.get('[data-screenshot-name="shot-a.png"]').find('button[aria-label="Move down"]').click();
         cy.wait('@gql');
         cy.reload();
-        cy.get('[data-screenshots-ready]', {timeout: 20000});
+        openEditorMediaTab();
         cy.get('[data-screenshot-name]').first().should('have.attr', 'data-screenshot-name', 'shot-b.png');
 
         // Delete the (now first) screenshot -> only shot-a.png remains. Deletion is
@@ -353,8 +385,57 @@ describe('Authoring views (JS module)', () => {
         cy.get('[data-screenshot-name="shot-b.png"]').contains('button', 'Delete').click();
         cy.wait('@gql');
         cy.reload();
-        cy.get('[data-screenshots-ready]', {timeout: 20000});
+        openEditorMediaTab();
         cy.get('[data-screenshot-name="shot-b.png"]').should('not.exist');
         cy.get('[data-screenshot-name="shot-a.png"]').should('exist');
+    });
+
+    it('owner can set and clear the module video in the editor Media tab', () => {
+        // Verify persistence via GraphQL rather than reloading the page: once a video
+        // exists the detail page embeds a YouTube iframe, which never loads in the
+        // offline test env and would hang cy.reload() waiting for the page load event.
+        cy.visit(moduleRender);
+        openEditorMediaTab();
+
+        // Set a YouTube video (creates the `video` child node + its properties).
+        cy.get('#edit-video-provider').select('youtube');
+        cy.get('[data-video-id]').clear().type('dQw4w9WgXcQ');
+        cy.get('[data-video-save]').click();
+        cy.contains('[data-video-manager] output', 'Saved', {timeout: 20000});
+        readProp(`${repo}/widget/video`, 'provider')
+            .its('data.jcr.nodeByPath.properties[0].value')
+            .should('equal', 'youtube');
+        readProp(`${repo}/widget/video`, 'identifier')
+            .its('data.jcr.nodeByPath.properties[0].value')
+            .should('equal', 'dQw4w9WgXcQ');
+
+        // Clear it (provider "None" + Save) -> the video node is deleted.
+        cy.get('#edit-video-provider').select('None');
+        cy.get('[data-video-save]').click();
+        cy.contains('[data-video-manager] output', 'Saved', {timeout: 20000});
+        // A missing node makes nodeByPath resolve to null/undefined (the field errors
+        // out for a non-existent path), so assert "not exist" rather than strictly null.
+        readProp(`${repo}/widget/video`, 'provider').its('data.jcr.nodeByPath').should('not.exist');
+    });
+
+    it('editor lists the configured categories (regression: was always "none configured")', () => {
+        // Wire a site root category + a child via the OSGi-backed admin path, then
+        // confirm the editor surfaces them. Guards the bug where the editor read the
+        // stale JCR `rootCategory` property instead of the OSGi forge config.
+        cy.apollo({
+            mutation: addNode,
+            variables: {parentPath: `/sites/${siteKey}`, name: 'cy-cats', primaryNodeType: 'jnt:category'}
+        }).then(result => {
+            const rootUuid = (result.data as {jcr: {addNode: {node: {uuid: string}}}}).jcr.addNode.node.uuid;
+            cy.apollo({mutation: setRootCategory, variables: {siteKey, rootCategoryUuid: rootUuid}});
+        });
+        cy.apollo({mutation: addForgeCategory, variables: {siteKey, name: 'widgets'}});
+
+        cy.visit(moduleRender);
+        cy.get('[data-editor-ready]', {timeout: 20000});
+        cy.contains('button', /edit module/i).click();
+        // The category control lives on the default (General) tab.
+        cy.contains('No categories are configured').should('not.exist');
+        cy.contains('label', /widgets/i, {timeout: 20000}).should('exist');
     });
 });

--- a/tests/cypress/e2e/17-authoring.cy.ts
+++ b/tests/cypress/e2e/17-authoring.cy.ts
@@ -438,4 +438,29 @@ describe('Authoring views (JS module)', () => {
         cy.contains('No categories are configured').should('not.exist');
         cy.contains('label', /widgets/i, {timeout: 20000}).should('exist');
     });
+
+    it('screenshot viewer: arrow keys navigate and Escape closes', () => {
+        // Two distinct screenshots so the detail-page lightbox has something to page
+        // through (same source image, different node names -> different URLs).
+        uploadFile('../../assets/screenshot.png', `${repo}/widget/screenshots`, 'kbd-1.png', 'image/png');
+        uploadFile('../../assets/screenshot.png', `${repo}/widget/screenshots`, 'kbd-2.png', 'image/png');
+
+        cy.visit(moduleRender);
+        // Open the viewer on the first screenshot (Overview is the default detail tab).
+        cy.get('[aria-label="Open screenshot"]', {timeout: 20000}).first().click();
+        cy.get('[data-lightbox]').should('exist');
+
+        cy.get('[data-lightbox-image]').invoke('attr', 'src').then(firstSrc => {
+            // ArrowRight advances to the next image...
+            cy.get('body').type('{rightarrow}');
+            cy.get('[data-lightbox-image]').should('have.attr', 'src').and('not.eq', firstSrc);
+            // ...ArrowLeft returns to the first.
+            cy.get('body').type('{leftarrow}');
+            cy.get('[data-lightbox-image]').should('have.attr', 'src', firstSrc);
+        });
+
+        // Escape closes the viewer.
+        cy.get('body').type('{esc}');
+        cy.get('[data-lightbox]').should('not.exist');
+    });
 });

--- a/tests/cypress/e2e/17-authoring.cy.ts
+++ b/tests/cypress/e2e/17-authoring.cy.ts
@@ -8,11 +8,13 @@ import {createSite, deleteSite, setNodeProperty, uploadFile} from '@jahia/cypres
  * a window object doesn't "detach" like a DOM element would mid-navigation, so no
  * assertion ends up straddling the reload.
  */
-const saveAndWaitReload = (saveLabel = /^Save$/): void => {
+const saveAndWaitReload = (): void => {
     cy.window().then(w => {
         (w as unknown as {__preSave?: boolean}).__preSave = true;
     });
-    cy.contains('button', saveLabel).click();
+    // The editor Save is an icon-only button (tooltip + aria-label); target its
+    // stable data hook rather than visible text.
+    cy.get('[data-editor-save]').click();
     cy.window({timeout: 20000}).should(w => {
         expect((w as unknown as {__preSave?: boolean}).__preSave).to.be.undefined;
     });

--- a/tests/cypress/e2e/17-authoring.cy.ts
+++ b/tests/cypress/e2e/17-authoring.cy.ts
@@ -447,7 +447,7 @@ describe('Authoring views (JS module)', () => {
 
         cy.visit(moduleRender);
         // Open the viewer on the first screenshot (Overview is the default detail tab).
-        cy.get('[aria-label="Open screenshot"]', {timeout: 20000}).first().click();
+        cy.get('[aria-label^="Open screenshot"]', {timeout: 20000}).first().click();
         cy.get('[data-lightbox]').should('exist');
 
         cy.get('[data-lightbox-image]').invoke('attr', 'src').then(firstSrc => {

--- a/tests/cypress/e2e/17-authoring.cy.ts
+++ b/tests/cypress/e2e/17-authoring.cy.ts
@@ -463,4 +463,33 @@ describe('Authoring views (JS module)', () => {
         cy.get('body').type('{esc}');
         cy.get('[data-lightbox]').should('not.exist');
     });
+
+    it('rejects an invalid video id without writing the video node', () => {
+        cy.intercept('POST', '/modules/graphql').as('gql');
+        cy.visit(moduleRender);
+        openEditorMediaTab();
+
+        cy.get('#edit-video-provider').select('youtube');
+        cy.get('[data-video-id]').clear().type('../../etc/passwd');
+        cy.get('[data-video-save]').click();
+
+        // The manager surfaces an error and writes nothing (the guard short-circuits before any
+        // GraphQL mutation), so the video node stays absent.
+        cy.get('[data-video-manager] [role="alert"]', {timeout: 20000}).should('be.visible');
+        readProp(`${repo}/widget/video`, 'provider').its('data.jcr.nodeByPath').should('not.exist');
+    });
+
+    it('uploads a screenshot through the Media-tab control and rejects a non-image', () => {
+        cy.visit(moduleRender);
+        openEditorMediaTab();
+
+        // Happy path: a PNG picked through the UI is uploaded and shown.
+        cy.get('[data-screenshot-input]').selectFile('assets/screenshot.png', {force: true});
+        cy.get('[data-screenshot-name="screenshot.png"]', {timeout: 20000}).should('exist');
+
+        // A non-image file is rejected client-side with an error and adds no thumbnail.
+        cy.get('[data-screenshot-input]').selectFile('assets/provisioning.yml', {force: true});
+        cy.get('[data-screenshots-ready] [role="alert"]', {timeout: 20000}).should('be.visible');
+        cy.get('[data-screenshot-name="provisioning.yml"]').should('not.exist');
+    });
 });

--- a/tests/cypress/e2e/19-richtext.cy.ts
+++ b/tests/cypress/e2e/19-richtext.cy.ts
@@ -3,11 +3,13 @@ import {createSite, deleteSite, setNodeProperty} from '@jahia/cypress';
 
 /** Click Save and wait for the full-page reload the editor triggers (reload-safe
  *  via a window stamp — see 17-authoring for the rationale). */
-const saveAndWaitReload = (saveLabel = /^Save$/): void => {
+const saveAndWaitReload = (): void => {
     cy.window().then(w => {
         (w as unknown as {__preSave?: boolean}).__preSave = true;
     });
-    cy.contains('button', saveLabel).click();
+    // The editor Save is an icon-only button (tooltip + aria-label); target its
+    // stable data hook rather than visible text.
+    cy.get('[data-editor-save]').click();
     cy.window({timeout: 20000}).should(w => {
         expect((w as unknown as {__preSave?: boolean}).__preSave).to.be.undefined;
     });

--- a/tests/cypress/e2e/20-accessibility.cy.ts
+++ b/tests/cypress/e2e/20-accessibility.cy.ts
@@ -1,6 +1,6 @@
 import {DocumentNode} from 'graphql';
 import {Result} from 'axe-core';
-import {createSite, deleteSite, setNodeProperty} from '@jahia/cypress';
+import {createSite, deleteSite, setNodeProperty, uploadFile} from '@jahia/cypress';
 
 /**
  * Accessibility gate (jahia-store-template JS module) — enforces the module's
@@ -118,6 +118,10 @@ describe('Accessibility — WCAG 2.2 AAA gate (JS module)', () => {
         setNodeProperty(`${repo}/seo`, 'description', '<p>Meta tags and sitemaps.</p>', 'en');
         setNodeProperty(`${repo}/seo`, 'status', 'community', 'en');
         setNodeProperty(`${repo}/seo`, 'published', 'true', 'en');
+
+        // Two screenshots so the detail page shows the lightbox (audited in its open state below).
+        uploadFile('../../assets/screenshot.png', `${repo}/analytics/screenshots`, 'a11y-1.png', 'image/png');
+        uploadFile('../../assets/screenshot.png', `${repo}/analytics/screenshots`, 'a11y-2.png', 'image/png');
     });
 
     after(() => {
@@ -147,6 +151,23 @@ describe('Accessibility — WCAG 2.2 AAA gate (JS module)', () => {
     it('"My modules" page has no WCAG 2.2 AAA violations', () => {
         cy.visit(render('/home/my-modules'));
         cy.contains('[data-forge-card]', 'Analytics Dashboard').should('be.visible');
+        audit();
+    });
+
+    it('the in-site editor (open) has no WCAG 2.2 AAA violations', () => {
+        cy.visit(detailRender);
+        cy.get('[data-editor-ready]', {timeout: 20000});
+        cy.contains('button', /edit module/i).click();
+        // The editor field tablist is present once the form is open.
+        cy.get('[aria-label="Module fields"]', {timeout: 20000}).should('be.visible');
+        audit();
+    });
+
+    it('the screenshot viewer (open) has no WCAG 2.2 AAA violations', () => {
+        cy.visit(detailRender);
+        cy.get('[data-detail-tabs-ready]', {timeout: 20000});
+        cy.get('[aria-label^="Open screenshot"]', {timeout: 20000}).first().click();
+        cy.get('[data-lightbox]').should('exist');
         audit();
     });
 });


### PR DESCRIPTION
## Summary

Test coverage + a small security hardening, accompanying the store-template editor/media/lightbox work and the multi-dimension blind review. `yarn lint` clean; **full Cypress E2E 110/110**.

## Tests added
- **JUnit (new layer — was 0):** 88 tests covering the SECURITY-571 security validators that previously had no unit coverage — `CreateEntryFromJar` path/coordinate/extension guards, `MavenProxy` SSRF/site-name guards, `ActionSecurityUtils` redirect + log sanitizer, `ForgeSettingsServiceImpl` LDAP-filter escape, `validateSiteKey`. (Validators relaxed `private`→package-private for same-package tests; they run in CI's `mvn install`.)
- **Cypress negatives:** MavenProxy traversal/scheme/bad-site → blocked (400/never-served); video invalid-id rejected without a write; screenshot upload-through-UI happy path + non-image rejection.
- **Cypress authoring/a11y:** editor Save by stable data-hook; Media-tab screenshot flow; video manager; category-list regression; lightbox keyboard nav; **axe audits of the editor-open and lightbox-open states**.

## Security hardening (found by the new tests)
- `validateSiteKey` and `MavenProxy.isValidSiteName` accepted a pure `".."` siteKey (the `[A-Za-z0-9._-]+` charset permits dots), which would resolve `/sites/..` to `/`. Both now reject any value containing `".."`.

## Test plan
- [x] `mvn clean install` green (JUnit 88/88)
- [x] `yarn lint` clean
- [x] Full Cypress E2E 110/110

Companion PR: store-template, same branch name.


---
Companion PR: https://github.com/Jahia/store-template/pull/19
