### PR TITLE
refactor(feeds): validate mavenproxy URL coordinates in the moduleList JSP feeds

### DIFF
--- a/src/main/resources/jnt_contentFolder/json/contentFolder.moduleList.jsp
+++ b/src/main/resources/jnt_contentFolder/json/contentFolder.moduleList.jsp
@@ -59,6 +59,9 @@
                                             <json:property name="requiredVersion"
                                                            value="${version.properties.requiredVersion.node.name}"/>
                                             <c:set var="files" value="${jcr:getChildrenOfType(version, 'jnt:file')}"/>
+                                            <%-- Reset per version so an unsafe-coordinate skip below can't leak the
+                                                 previous version's URL into this entry. --%>
+                                            <c:set var="downloadUrl" value=""/>
                                             <c:if test="${empty files}">
                                                 <%-- No attached artifact: the module was deployed to the site's Maven
                                                      repository, so the download is served by the MavenProxy servlet at
@@ -70,7 +73,13 @@
                                                      {groupId-with-dots-as-slashes}/{name}/{version}/{name}-{version}.jar
                                                      Also implemented in rss/contentFolder.moduleList.jsp and, root-relative
                                                      for the browser, in store-template src/components/forge/versions.ts. --%>
-                                                <c:set var="downloadUrl" value="${url.server}${url.context}/modules/mavenproxy/${currentNode.resolveSite.siteKey}/${fn:replace(groupID, '.', '/')}/${child.name}/${version.properties.versionNumber.string}/${child.name}-${version.properties.versionNumber.string}.jar"/>
+                                                <c:set var="vNum" value="${version.properties.versionNumber.string}"/>
+                                                <%-- Skip the URL when a coordinate could deepen/traverse the proxy path
+                                                     (".." or "/"), mirroring the SAFE_MAVEN_SEGMENT guard in versions.ts so
+                                                     this feed never emits a path the proxy/storefront would reject. --%>
+                                                <c:if test="${not (fn:contains(groupID, '..') or fn:contains(groupID, '/') or fn:contains(child.name, '..') or fn:contains(child.name, '/') or fn:contains(vNum, '..') or fn:contains(vNum, '/'))}">
+                                                    <c:set var="downloadUrl" value="${url.server}${url.context}/modules/mavenproxy/${currentNode.resolveSite.siteKey}/${fn:replace(groupID, '.', '/')}/${child.name}/${vNum}/${child.name}-${vNum}.jar"/>
+                                                </c:if>
                                             </c:if>
                                             <c:if test="${not empty files}">
                                                 <c:forEach var="file" items="${files}">

--- a/src/main/resources/jnt_contentFolder/rss/contentFolder.moduleList.jsp
+++ b/src/main/resources/jnt_contentFolder/rss/contentFolder.moduleList.jsp
@@ -22,6 +22,9 @@
                 <c:if test="${version.properties.published.boolean}">
                     <c:set var="module" value="${version.parent}"/>
                     <c:set var="files" value="${jcr:getChildrenOfType(version, 'jnt:file')}"/>
+                    <%-- Reset per version so an unsafe-coordinate skip below can't leak the previous
+                         item's URL into this <item>. --%>
+                    <c:set var="downloadUrl" value=""/>
                     <c:choose>
                         <c:when test="${not empty files}">
                             <c:forEach var="file" items="${files}">
@@ -38,7 +41,13 @@
                                  json/contentFolder.moduleList.jsp; MavenProxy.java parses it back):
                                  {server}{context}/modules/mavenproxy/{siteKey}/{groupId-as-path}/
                                  {name}/{version}/{name}-{version}.jar --%>
-                            <c:set var="downloadUrl" value="${url.server}${url.context}/modules/mavenproxy/${currentNode.resolveSite.siteKey}/${fn:replace(module.properties['groupId'].string, '.', '/')}/${module.name}/${version.properties.versionNumber.string}/${module.name}-${version.properties.versionNumber.string}.jar"/>
+                            <c:set var="grp" value="${module.properties['groupId'].string}"/>
+                            <c:set var="vNum" value="${version.properties.versionNumber.string}"/>
+                            <%-- Skip the URL when a coordinate could deepen/traverse the proxy path
+                                 (".." or "/"), mirroring SAFE_MAVEN_SEGMENT in versions.ts. --%>
+                            <c:if test="${not (fn:contains(grp, '..') or fn:contains(grp, '/') or fn:contains(module.name, '..') or fn:contains(module.name, '/') or fn:contains(vNum, '..') or fn:contains(vNum, '/'))}">
+                                <c:set var="downloadUrl" value="${url.server}${url.context}/modules/mavenproxy/${currentNode.resolveSite.siteKey}/${fn:replace(grp, '.', '/')}/${module.name}/${vNum}/${module.name}-${vNum}.jar"/>
+                            </c:if>
                         </c:otherwise>
                     </c:choose>
                 <item>


### PR DESCRIPTION
## Summary

Contained architecture cleanup from the blind review. `yarn lint` clean; **full Cypress E2E 112/112** (incl. spec 14 download + traversal tests).

- **Validate mavenproxy URL coordinates in the moduleList feeds.** The json + rss `moduleList` feeds built the `/modules/mavenproxy` download URL from author-supplied coordinates with no validation, while store-template `versions.ts` rejects unsafe segments (`SAFE_MAVEN_SEGMENT`) — so the feeds could emit a URL the storefront/proxy would refuse (contract drift). Both feeds now reset `downloadUrl` per version and skip the URL when `groupId`/`name`/`version` contains `..` or `/`, mirroring the TS guard. No change for legitimate coordinates. (The proxy's `isSuspicious` remains the request-time backstop.)

The `CreateEntryFromJar` god-file split (which would also clear the deferred Sonar duplication) remains future work.

## Test plan
- [x] `mvn clean install` green (JUnit 88/88)
- [x] Full Cypress E2E 112/112

Companion PR: store-template, same branch name.


---
Companion PR: https://github.com/Jahia/store-template/pull/21
