### PR TITLE
test(feeds): spanning test for the moduleList coordinate guard (MavenProxy URL grammar)

### DIFF
--- a/tests/cypress/e2e/14-moduleListAndDownload.cy.ts
+++ b/tests/cypress/e2e/14-moduleListAndDownload.cy.ts
@@ -308,4 +308,53 @@ describe('Module list JSON + download', () => {
             });
         });
     });
+
+    it('suppresses the download URL when a module coordinate carries a forbidden segment (feed guard)', () => {
+        // The upload action rejects unsafe coordinates, but a direct JCR/GraphQL write could plant
+        // one. Both moduleList feeds build the mavenproxy URL from the coordinates, so they must
+        // skip emitting it (mirroring versions.ts SAFE_MAVEN_SEGMENT) rather than serve a URL the
+        // storefront would refuse and MavenProxy.java would reject — the "spanning test" the
+        // architecture review flagged as missing for the 3-place URL grammar.
+        const badName = 'cy-bad-coord';
+        const badModulePath = `${repositoryPath}/${badName}`;
+        const badGroupId = 'org/evil/../secret'; // Carries both '/' and '..'
+        cy.apollo({
+            mutation: createForgeModule,
+            variables: {parentPath: repositoryPath, name: badName, title: 'Bad Coord'}
+        });
+        cy.apollo({
+            mutation: addNodeWithProps,
+            variables: {
+                parentPath: badModulePath,
+                name: `${badName}-1.0.0`,
+                primaryNodeType: 'jnt:forgeModuleVersion',
+                properties: [{name: 'versionNumber', value: '1.0.0'}]
+            }
+        });
+        setNodeProperty(badModulePath, 'groupId', badGroupId, 'en');
+        setNodeProperty(badModulePath, 'published', 'true', 'en');
+        setNodeProperty(`${badModulePath}/${badName}-1.0.0`, 'published', 'true', 'en');
+        publishAndWaitJobEnding(`/sites/${siteKey}`, ['en']);
+
+        // JSON feed: the guarded version's downloadUrl is suppressed — never a mavenproxy/traversal URL.
+        cy.request({url: jsonUrl, failOnStatusCode: false}).then(res => {
+            const payload = Array.isArray(res.body) ? res.body[0] : res.body;
+            const modules =
+                (payload as {modules?: Array<{name: string; versions: Array<{version: string; downloadUrl?: string}>}>})
+                    .modules || [];
+            const bad = modules.find(m => m.name === badName);
+            expect(bad, 'forbidden-coordinate module present in feed').to.not.be.undefined;
+            const v = bad!.versions.find(x => x.version === '1.0.0');
+            const downloadUrl = v?.downloadUrl ?? '';
+            expect(downloadUrl, 'forbidden-coordinate downloadUrl is suppressed')
+                .to.satisfy((u: string) => u === '' || (!u.includes('/modules/mavenproxy/') && !u.includes('..')));
+        });
+
+        // RSS feed: the same guard means no item links to a traversal coordinate.
+        const rssUrl = `/en/sites/${siteKey}/contents/modules-repository.moduleList.rss`;
+        cy.request({url: rssUrl, failOnStatusCode: false}).then(res => {
+            expect(res.status).to.equal(200);
+            expect(String(res.body), 'rss feed must not emit the traversal coordinate').to.not.contain('org/evil');
+        });
+    });
 });


### PR DESCRIPTION
## What

Closes the last open piece of the architecture review's **MavenProxy URL-grammar** finding.

The finding: the mavenproxy download-URL grammar is built in **3 places** — `json` JSP, `rss` JSP, and `versions.ts` — and the two JSPs skipped the segment validation `versions.ts` enforces, **"with no spanning test."** PR #39 added the `..`/`/` coordinate guard to both feeds; this adds the missing test.

The test seeds (via direct GraphQL, bypassing the upload action's `isSafeCoordinate` check, the way a raw JCR/GraphQL write could) a jnt:file-less version under a module whose `groupId` carries both `/` and `..`, publishes, then asserts **both** feeds suppress the URL:
- **JSON** — that version's `downloadUrl` is empty (no `/modules/mavenproxy/` path, no `..`).
- **RSS** — the feed never links the traversal coordinate.

## Verification
- `14-moduleListAndDownload` **8/8** against the live stack (incl. the new test).

## Test plan
- [x] Forbidden coordinate → suppressed URL in both feeds
- [ ] CI green