### PR TITLE
refactor(graphql): extract shared site-access guard (cut forge mutation duplication)

### DIFF
--- a/src/main/java/org/jahia/modules/forge/graphql/CategorySettingsMutationExtension.java
+++ b/src/main/java/org/jahia/modules/forge/graphql/CategorySettingsMutationExtension.java
@@ -6,7 +6,6 @@ import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLNonNull;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.apache.commons.lang.StringUtils;
-import org.apache.jackrabbit.core.fs.FileSystem;
 import org.jahia.modules.forge.settings.ForgeSettingsService;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
 import org.jahia.services.content.JCRCallback;
@@ -14,8 +13,6 @@ import org.jahia.services.content.JCRContentUtils;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.JCRSessionFactory;
 import org.jahia.services.content.JCRSessionWrapper;
-import org.jahia.services.content.JCRTemplate;
-import org.jahia.services.sites.JahiaSitesService;
 
 import javax.jcr.AccessDeniedException;
 import javax.jcr.ItemNotFoundException;
@@ -29,7 +26,6 @@ import java.util.Locale;
 public final class CategorySettingsMutationExtension {
 
     private static final String PERMISSION = "siteAdminForgeSettings";
-    private static final String SITES_PATH = JahiaSitesService.SITES_JCR_PATH + FileSystem.SEPARATOR;
     private static final String JCR_TITLE = "jcr:title";
     private static final String JNT_CATEGORY = "jnt:category";
     private static final String WORKSPACE_DEFAULT = "default";
@@ -184,25 +180,7 @@ public final class CategorySettingsMutationExtension {
     }
 
     private static <T> T execute(String siteKey, JCRCallback<T> work) {
-        ForgeSettingsMutationExtension.validateSiteKey(siteKey);
-        try {
-            return JCRTemplate.getInstance().doExecuteWithSystemSession(session -> {
-                final String sitePath = SITES_PATH + siteKey;
-                if (!session.nodeExists(sitePath)) {
-                    throw new RepositoryException("Site not found: " + siteKey);
-                }
-
-                final JCRSessionWrapper callerSession = JCRSessionFactory.getInstance().getCurrentUserSession();
-                if (!callerSession.nodeExists(sitePath)
-                        || !callerSession.getNode(sitePath).hasPermission(PERMISSION)) {
-                    throw new AccessDeniedException(PERMISSION);
-                }
-
-                return work.doInJCR(session);
-            });
-        } catch (RepositoryException e) {
-            throw new ForgeSettingsException(
-                    "Category settings mutation failed for site " + siteKey, e);
-        }
+        return ForgeSiteAccess.executeAsSystemForSite(
+                siteKey, PERMISSION, "Category settings mutation failed for site ", work);
     }
 }

--- a/src/main/java/org/jahia/modules/forge/graphql/ForgeSiteAccess.java
+++ b/src/main/java/org/jahia/modules/forge/graphql/ForgeSiteAccess.java
@@ -1,0 +1,50 @@
+package org.jahia.modules.forge.graphql;
+
+import org.apache.jackrabbit.core.fs.FileSystem;
+import org.jahia.services.content.JCRCallback;
+import org.jahia.services.content.JCRSessionFactory;
+import org.jahia.services.content.JCRSessionWrapper;
+import org.jahia.services.content.JCRTemplate;
+import org.jahia.services.sites.JahiaSitesService;
+
+import javax.jcr.AccessDeniedException;
+import javax.jcr.RepositoryException;
+
+/**
+ * Shared site-scoped execution guard for the forge GraphQL mutation extensions. Validates the
+ * siteKey, then runs {@code work} in a system session — but only after confirming the CALLER can
+ * read the site node and holds {@code permission} on it (AccessDenied otherwise). Extracted so the
+ * Category-settings and Manage-roles mutations share one copy of this authorization guard
+ * (SECURITY-571) instead of each carrying an identical private {@code execute()}.
+ */
+final class ForgeSiteAccess {
+
+    private static final String SITES_PATH = JahiaSitesService.SITES_JCR_PATH + FileSystem.SEPARATOR;
+
+    private ForgeSiteAccess() {
+        // Utility class — not instantiable.
+    }
+
+    static <T> T executeAsSystemForSite(String siteKey, String permission, String failureMessage,
+                                        JCRCallback<T> work) {
+        ForgeSettingsMutationExtension.validateSiteKey(siteKey);
+        try {
+            return JCRTemplate.getInstance().doExecuteWithSystemSession(session -> {
+                final String sitePath = SITES_PATH + siteKey;
+                if (!session.nodeExists(sitePath)) {
+                    throw new RepositoryException("Site not found: " + siteKey);
+                }
+
+                final JCRSessionWrapper callerSession = JCRSessionFactory.getInstance().getCurrentUserSession();
+                if (!callerSession.nodeExists(sitePath)
+                        || !callerSession.getNode(sitePath).hasPermission(permission)) {
+                    throw new AccessDeniedException(permission);
+                }
+
+                return work.doInJCR(session);
+            });
+        } catch (RepositoryException e) {
+            throw new ForgeSettingsException(failureMessage + siteKey, e);
+        }
+    }
+}

--- a/src/main/java/org/jahia/modules/forge/graphql/ManageRolesMutationExtension.java
+++ b/src/main/java/org/jahia/modules/forge/graphql/ManageRolesMutationExtension.java
@@ -9,13 +9,8 @@ import org.apache.jackrabbit.core.fs.FileSystem;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
 import org.jahia.services.content.JCRCallback;
 import org.jahia.services.content.JCRNodeWrapper;
-import org.jahia.services.content.JCRSessionFactory;
-import org.jahia.services.content.JCRSessionWrapper;
-import org.jahia.services.content.JCRTemplate;
 import org.jahia.services.sites.JahiaSitesService;
 
-import javax.jcr.AccessDeniedException;
-import javax.jcr.RepositoryException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -118,27 +113,7 @@ public final class ManageRolesMutationExtension {
     }
 
     private static <T> T execute(String siteKey, JCRCallback<T> work) {
-        // Reject a path-traversal siteKey before it is concatenated into a JCR site path — the
-        // sibling mutation/query extensions all validate first; this one must too (SECURITY-571).
-        ForgeSettingsMutationExtension.validateSiteKey(siteKey);
-        try {
-            return JCRTemplate.getInstance().doExecuteWithSystemSession(session -> {
-                final String sitePath = SITES_PATH + siteKey;
-                if (!session.nodeExists(sitePath)) {
-                    throw new RepositoryException("Site not found: " + siteKey);
-                }
-
-                final JCRSessionWrapper callerSession = JCRSessionFactory.getInstance().getCurrentUserSession();
-                if (!callerSession.nodeExists(sitePath)
-                        || !callerSession.getNode(sitePath).hasPermission(PERMISSION)) {
-                    throw new AccessDeniedException(PERMISSION);
-                }
-
-                return work.doInJCR(session);
-            });
-        } catch (RepositoryException e) {
-            throw new ForgeSettingsException(
-                    "Manage-roles mutation failed for site " + siteKey, e);
-        }
+        return ForgeSiteAccess.executeAsSystemForSite(
+                siteKey, PERMISSION, "Manage-roles mutation failed for site ", work);
     }
 }


### PR DESCRIPTION
## What

`CategorySettingsMutationExtension` and `ManageRolesMutationExtension` each carried an **identical ~15-line private `execute(siteKey, work)`** — validate the siteKey, run the work in a system session, but only after confirming the **caller** can read the site node and holds the extension's `PERMISSION` (AccessDenied otherwise). SonarQube flagged this as the largest duplicated block on new code.

Extracted it into a single `ForgeSiteAccess.executeAsSystemForSite(siteKey, permission, failureMessage, work)`; both extensions now delegate. Behaviour is **identical** — the permission and the failure-message prefix were the only per-extension differences, now parameters. Also removed the orphaned `SITES_PATH` constant + now-unused imports from `CategorySettings` (no other use), keeping them in `ManageRoles` (still used by its other methods).

## Effect (verified by a fresh main-branch scan)
- Overall `duplicated_lines_density`: **2.5% → 1.4%**.
- `graphql` package duplicated lines: **52 (3 blocks) → 10 (1 block)**.
- `new_duplicated_lines_density`: 3.65% → **3.24%** (still marginally over the 3% gate).

The residual 0.24% is inherent graphql-java input/output DTO boilerplate within a small new-code window — not cleanly/safely dedup-able (the project has deferred such DTO merges before), and it clears once the new-code baseline rolls. This PR is a net duplication reduction, so its own delta gate passes.

## Verification
- `mvn clean install`: **88 JUnit tests green**.
- Backs the category/roles admin mutations — E2E (06/07/09/10) being re-run against the redeployed module.

## Test plan
- [x] 88 JUnit green; duplication reduced
- [ ] CI green
- [ ] Category/roles admin E2E green