### PR TITLE
feat: default forge-settings config (karaf/etc) + clear 'version already exists' upload error

### DIFF
--- a/src/main/java/org/jahia/modules/forge/actions/CreateEntryFromJar.java
+++ b/src/main/java/org/jahia/modules/forge/actions/CreateEntryFromJar.java
@@ -462,10 +462,25 @@ public class CreateEntryFromJar extends Action {
             deployToMaven(groupId, moduleName, moduleReleaseInfo, artifact);
             return null;
         } catch (IOException e) {
-            return errorResult(session, "forge.uploadJar.error.cannot.upload");
+            // A release repository (e.g. Nexus hosted "release") refuses to overwrite an existing
+            // version -> surface an actionable "bump the version" message instead of the raw Maven
+            // failure. Any other deploy error stays generic (the detail is in the server log).
+            final String key = isVersionAlreadyDeployed(e.getMessage())
+                    ? "forge.uploadJar.error.version.already.deployed"
+                    : "forge.uploadJar.error.cannot.upload";
+            return errorResult(session, key);
         } finally {
             FileUtils.deleteQuietly(artifact);
         }
+    }
+
+    /**
+     * True when a Maven deploy failed because the version already exists in a release repository:
+     * Nexus answers HTTP 400 "... cannot be updated" (redeploy disabled on release repos). Matched
+     * on that phrase, which {@link #getMavenError} keeps from the {@code [ERROR]} lines.
+     */
+    static boolean isVersionAlreadyDeployed(String mavenError) {
+        return mavenError != null && StringUtils.containsIgnoreCase(mavenError, "cannot be updated");
     }
 
     /**

--- a/src/main/java/org/jahia/modules/forge/settings/ForgeSettingsServiceImpl.java
+++ b/src/main/java/org/jahia/modules/forge/settings/ForgeSettingsServiceImpl.java
@@ -130,10 +130,7 @@ public class ForgeSettingsServiceImpl implements ForgeSettingsService {
     }
 
     private ForgeSettings toSettings(Dictionary<String, Object> d) {
-        final String pw64 = str(d, P_PASSWORD);
-        final String password = StringUtils.isNotBlank(pw64)
-                ? new String(Base64.getDecoder().decode(pw64), StandardCharsets.UTF_8)
-                : null;
+        final String password = decodePassword(str(d, P_PASSWORD));
         return ForgeSettings.builder()
                 .url(str(d, P_URL))
                 .id(str(d, P_ID))
@@ -155,6 +152,23 @@ public class ForgeSettingsServiceImpl implements ForgeSettingsService {
     private static String str(Dictionary<String, Object> d, String key) {
         final Object v = d.get(key);
         return (v != null) ? v.toString() : null;
+    }
+
+    /**
+     * Decode the stored password. {@link #save} (and the admin UI) store it base64-encoded, but a
+     * value hand-typed into the {@code karaf/etc} .cfg may not be valid base64 — fall back to the
+     * raw value instead of letting {@link Base64} throw, which would break every {@code get()} for
+     * the site (the proxy, the upload deploy, the storefront chrome all call it).
+     */
+    static String decodePassword(String stored) {
+        if (StringUtils.isBlank(stored)) {
+            return null;
+        }
+        try {
+            return new String(Base64.getDecoder().decode(stored), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            return stored;
+        }
     }
 
     private static void putOrRemove(Dictionary<String, Object> d, String key, String value) {

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.forge.forgeSettings-default.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.forge.forgeSettings-default.cfg
@@ -1,0 +1,45 @@
+# default configuration - won't be overridden
+#
+# Private App Store - per-site settings (OSGi factory configuration
+# "org.jahia.modules.forge.forgeSettings"; one configuration instance per site).
+#
+# On install this file is deployed to <JAHIA_HOME>/digital-factory-data/karaf/etc/ and is
+# SAFE TO EDIT there: the "won't be overridden" marker on the first line stops Jahia from
+# overwriting your changes the next time the module is (re)deployed. The same settings are
+# also editable in-product through the store administration UI.
+#
+# IMPORTANT: these settings only apply to the site whose key matches "siteKey" below, so set
+# it to your store's site. To run several stores, copy this file per site as
+# "org.jahia.modules.forge.forgeSettings-<siteKey>.cfg" and set "siteKey" in each.
+
+# Site key of the store these settings apply to (the <siteKey> in /sites/<siteKey>).
+siteKey=
+
+# --- Maven release repository (where uploaded module JARs are deployed, and downloads proxied from) ---
+# Full URL of the hosted RELEASE repository (e.g. a Nexus hosted "release" repo). NOTE: release
+# repositories reject re-deploying an existing version - bump the module version to publish again.
+url=
+# repositoryId - must match the <server> id whose credentials authenticate the deploy.
+id=remote-repository
+# Username used SERVER-SIDE for the Maven deploy (and proxy fetch); never returned to clients.
+user=
+# Password for the user above, BASE64-ENCODED - this is how the store stores it, and the
+# administration UI encodes it for you. To set it by hand, base64-encode the plaintext, e.g.:
+#     printf '%s' 'your-password' | base64
+password=
+
+# --- Catalog ---
+# UUID of the JCR category node under which this store's module categories live.
+rootCategoryUuid=
+
+# --- Storefront branding (all optional) ---
+# DAM path of the header logo (e.g. /sites/<siteKey>/files/store-logo.png).
+logoPath=
+copyright=
+privacyUrl=
+termsUrl=
+cookiesUrl=
+facebookUrl=
+linkedinUrl=
+twitterUrl=
+youtubeUrl=

--- a/src/main/resources/resources/jahia-store.properties
+++ b/src/main/resources/resources/jahia-store.properties
@@ -313,3 +313,4 @@ forge.uploadJar.error.unable.read.file=Unable to read the artifact
 forge.uploadJar.error.file.too.large=The uploaded module file is too large (maximum 200 MB).
 forge.uploadJar.error.snapshot.not.allowed=Only released modules are allowed.
 forge.uploadJar.error.versionNumber=Cannot upload module {0} because version {1} already exists.
+forge.uploadJar.error.version.already.deployed=This module version already exists in the store repository, and released versions cannot be overwritten. Increase the module version and upload again.

--- a/src/test/java/org/jahia/modules/forge/actions/CreateEntryFromJarValidatorTest.java
+++ b/src/test/java/org/jahia/modules/forge/actions/CreateEntryFromJarValidatorTest.java
@@ -109,4 +109,24 @@ class CreateEntryFromJarValidatorTest {
         // For an accepted extension the returned value is the interned constant, not the input slice.
         assertThat(CreateEntryFromJar.trustedExtension("a.JAR")).isNull(); // case-sensitive: only lowercase jar
     }
+
+    @Test
+    @DisplayName("isVersionAlreadyDeployed detects the Nexus release-repo 'cannot be updated' 400")
+    void isVersionAlreadyDeployed_nexusRedeployBlocked() {
+        final String mavenError = " Failed to deploy artifacts: Could not transfer artifact "
+                + "org.jahia.community.modules:autofileuploader:jar:2.0.0 ... status: 400 "
+                + "jahia-public-app-store/.../autofileuploader-2.0.0.jar cannot be updated -> [Help 1]";
+        assertThat(CreateEntryFromJar.isVersionAlreadyDeployed(mavenError)).isTrue();
+        // Case-insensitive (defensive against future Nexus phrasing tweaks).
+        assertThat(CreateEntryFromJar.isVersionAlreadyDeployed("artifact CANNOT BE UPDATED")).isTrue();
+    }
+
+    @Test
+    @DisplayName("isVersionAlreadyDeployed is false for other deploy failures and null")
+    void isVersionAlreadyDeployed_otherFailures() {
+        assertThat(CreateEntryFromJar.isVersionAlreadyDeployed(null)).isFalse();
+        assertThat(CreateEntryFromJar.isVersionAlreadyDeployed(
+                "Could not transfer artifact ...: Authentication failed ... 401 Unauthorized")).isFalse();
+        assertThat(CreateEntryFromJar.isVersionAlreadyDeployed("Connection refused")).isFalse();
+    }
 }

--- a/src/test/java/org/jahia/modules/forge/settings/ForgeSettingsServiceImplTest.java
+++ b/src/test/java/org/jahia/modules/forge/settings/ForgeSettingsServiceImplTest.java
@@ -3,6 +3,9 @@ package org.jahia.modules.forge.settings;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -35,5 +38,29 @@ class ForgeSettingsServiceImplTest {
                 .isEqualTo("\\2a\\29\\28uid=\\2a");
         // Backslash is escaped before the others so its own escape is not re-escaped.
         assertThat(ForgeSettingsServiceImpl.escape("\\*")).isEqualTo("\\5c\\2a");
+    }
+
+    @Test
+    @DisplayName("decodePassword returns null for a blank value")
+    void decodePassword_blank() {
+        assertThat(ForgeSettingsServiceImpl.decodePassword(null)).isNull();
+        assertThat(ForgeSettingsServiceImpl.decodePassword("")).isNull();
+        assertThat(ForgeSettingsServiceImpl.decodePassword("   ")).isNull();
+    }
+
+    @Test
+    @DisplayName("decodePassword decodes a base64-encoded value (how save()/the UI store it)")
+    void decodePassword_base64() {
+        final String encoded = Base64.getEncoder().encodeToString("s3cr3t!".getBytes(StandardCharsets.UTF_8));
+        assertThat(ForgeSettingsServiceImpl.decodePassword(encoded)).isEqualTo("s3cr3t!");
+    }
+
+    @Test
+    @DisplayName("decodePassword falls back to the raw value when it is not valid base64 (hand-edited .cfg)")
+    void decodePassword_plaintextFallback() {
+        // A password typed straight into karaf/etc — the space and '!' make it invalid base64, so
+        // it must be used as-is rather than throwing (which would break every get() for the site).
+        assertThat(ForgeSettingsServiceImpl.decodePassword("my plaintext pwd!"))
+                .isEqualTo("my plaintext pwd!");
     }
 }


### PR DESCRIPTION
Two store-admin/upload usability improvements (from a support ticket where a module upload failed with a raw Maven `400 … cannot be updated`).

## 1. Default forge-settings config, editable in `karaf/etc`
New `META-INF/configurations/org.jahia.modules.forge.forgeSettings-default.cfg` — a documented factory-config instance of the existing `ForgeSettingsService` PID. After install it deploys to `JAHIA_HOME/digital-factory-data/karaf/etc/` so an admin can configure a site's store (Nexus release repo `url`/`id`/`user`/`password`, category root, branding) by editing the file, not only via the admin UI. The admin sets `siteKey` to their site.

The mandatory `# default configuration - won't be overridden` first line keeps edits from being reverted on the next (re)deploy.

**Also hardened** `ForgeSettingsServiceImpl.decodePassword`: the password is stored base64-encoded by `save()`/the UI, but a value hand-typed into the `.cfg` may not be valid base64 — it now falls back to the raw value instead of letting `Base64` throw (which would break every `get()` for the site).

## 2. Clear "version already exists" upload error
A release repo refuses to overwrite a published version (`mvn deploy:deploy-file` → HTTP `400 … cannot be updated`). The action mapped every deploy `IOException` to the generic *"Unable to upload artifact to the repository"*. It now detects that Nexus phrase (`isVersionAlreadyDeployed`) and returns an actionable message: *"This module version already exists … Increase the module version and upload again."* Other failures keep the generic message (detail stays server-side).

## Verification
- `mvn clean install`: **93 JUnit** (5 new — 3 decode-fallback, 2 detector).
- Deploy validated on a running stack: log shows *"Copied configuration file … into /var/jahia/karaf/etc/org.jahia.modules.forge.forgeSettings-default.cfg"* + Felix *"Creating configuration {…forgeSettings~default}"*, and an admin edit to that file **survived a module redeploy** (marker works).

## Test plan
- [x] Config ships → deploys to karaf/etc → registered → edits survive redeploy
- [x] Tolerant password decode (base64 + plaintext fallback)
- [x] Friendly version-exists message; generic for other failures
- [ ] CI green