### PR TITLE
SECURITY-571: E2E coverage for storefront search + editor UX polish

### DIFF
--- a/tests/cypress/e2e/16-storefront.cy.ts
+++ b/tests/cypress/e2e/16-storefront.cy.ts
@@ -37,6 +37,28 @@ describe('Storefront read views (JS module)', () => {
     const addNode = (parentPath: string, name: string, primaryNodeType: string, properties: object[] = []) =>
         cy.apollo({mutation: addNodeWithProps, variables: {parentPath, name, primaryNodeType, properties}});
 
+    /**
+     * Clear the header search via its native clear gesture (the `search` event) and wait for the
+     * programmatic-submit reload it triggers. `.trigger('search')` causes a requestSubmit()
+     * navigation that Cypress doesn't track as a page-load like a click/{enter} does, so a bare
+     * assertion straight after would straddle the reload (and inherit the empty subject the
+     * @jahia/cypress console-error logger injects on window:load). Stamping window and waiting for
+     * the stamp to vanish is reload-safe — a window object doesn't detach mid-navigation like a DOM
+     * node — so later assertions run on the settled, reloaded page. Mirrors 17-authoring's
+     * saveAndWaitReload.
+     */
+    const clearHeaderSearchAndWaitReload = (): void => {
+        cy.window().then(w => {
+            (w as unknown as {__preClear?: boolean}).__preClear = true;
+        });
+        cy.get('header [role="search"] input[name="src_terms"]:visible', {timeout: 20000})
+            .clear()
+            .trigger('search');
+        cy.window({timeout: 20000}).should(w => {
+            expect((w as unknown as {__preClear?: boolean}).__preClear).to.be.undefined;
+        });
+    };
+
     before(function () {
         cy.request({url: islandBundle, failOnStatusCode: false}).then(res => {
             if (res.status !== 200) {
@@ -198,6 +220,36 @@ describe('Storefront read views (JS module)', () => {
             .should('exist');
         cy.get('header [role="search"] input[name="src_terms"]:visible').type('toolkit{enter}');
         cy.location('search').should('include', 'src_terms=toolkit').and('include', 'status=community');
+        cy.contains('[data-forge-card]', 'SEO Toolkit').should('be.visible');
+        cy.contains('[data-forge-card]', 'Analytics Dashboard').should('not.exist');
+    });
+
+    it('re-applies the filter when the search is cleared, dropping the keyword', () => {
+        cy.visit(`${homeRender}?src_terms=seo`);
+        cy.get('[data-forge-list]', {timeout: 20000});
+        cy.contains('[data-forge-card]', 'SEO Toolkit').should('be.visible');
+        cy.contains('[data-forge-card]', 'Analytics Dashboard').should('not.exist');
+        // The native type=search "×" empties the field but does not submit; clearing fires a
+        // `search` event and the AdvancedSearchSync island submits the now-empty form, so the
+        // keyword filter lifts without the user pressing Enter. (Cypress can't click the native
+        // clear pseudo-element, so we reproduce the gesture: clear the value + emit `search`.)
+        clearHeaderSearchAndWaitReload();
+        // On the settled, reloaded page the keyword is gone and the previously filtered-out module
+        // is back.
+        cy.location('search').should('not.contain', 'src_terms=seo');
+        cy.contains('[data-forge-card]', 'Analytics Dashboard').should('be.visible');
+    });
+
+    it('keeps the active status facet when the search is cleared', () => {
+        cy.visit(`${homeRender}?status=community&src_terms=toolkit`);
+        // Wait for the island to inject the carried facet as a hidden input before clearing,
+        // else the cleared submit would drop it.
+        cy.get('header [role="search"] input[type="hidden"][name="status"][value="community"]', {timeout: 20000})
+            .should('exist');
+        clearHeaderSearchAndWaitReload();
+        // On the settled, reloaded page the keyword is gone but the carried status facet survives.
+        cy.location('search').should('include', 'status=community').and('not.contain', 'src_terms=toolkit');
+        // The community filter still excludes the supported module.
         cy.contains('[data-forge-card]', 'SEO Toolkit').should('be.visible');
         cy.contains('[data-forge-card]', 'Analytics Dashboard').should('not.exist');
     });

--- a/tests/cypress/e2e/17-authoring.cy.ts
+++ b/tests/cypress/e2e/17-authoring.cy.ts
@@ -434,9 +434,43 @@ describe('Authoring views (JS module)', () => {
         cy.visit(moduleRender);
         cy.get('[data-editor-ready]', {timeout: 20000});
         cy.contains('button', /edit module/i).click();
-        // The category control lives on the default (General) tab.
+        // The category control lives on the default (General) tab. Categories now use a
+        // tag-style chip picker: a configured-but-unselected category appears as an option
+        // in the add-dropdown (not a checkbox label).
         cy.contains('No categories are configured').should('not.exist');
-        cy.contains('label', /widgets/i, {timeout: 20000}).should('exist');
+        cy.get('#edit-category', {timeout: 20000}).find('option').contains(/widgets/i).should('exist');
+    });
+
+    it('category picker works like the tag chips: pick adds a chip, × removes it', () => {
+        // Configure two categories so the dropdown still offers one after the first is picked.
+        cy.apollo({
+            mutation: addNode,
+            variables: {parentPath: `/sites/${siteKey}`, name: 'cy-cats2', primaryNodeType: 'jnt:category'}
+        }).then(result => {
+            const rootUuid = (result.data as {jcr: {addNode: {node: {uuid: string}}}}).jcr.addNode.node.uuid;
+            cy.apollo({mutation: setRootCategory, variables: {siteKey, rootCategoryUuid: rootUuid}});
+        });
+        cy.apollo({mutation: addForgeCategory, variables: {siteKey, name: 'alpha'}});
+        cy.apollo({mutation: addForgeCategory, variables: {siteKey, name: 'beta'}});
+
+        cy.visit(moduleRender);
+        cy.get('[data-editor-ready]', {timeout: 20000});
+        cy.contains('button', /edit module/i).click();
+
+        // Pick "alpha" from the add-dropdown — it becomes a removable chip and leaves the dropdown.
+        cy.get('#edit-category', {timeout: 20000}).select('alpha');
+        cy.get('[data-category-select]').contains('li', 'alpha').should('be.visible');
+        cy.get('#edit-category').find('option').contains(/alpha/i).should('not.exist');
+        // "beta" is still offered.
+        cy.get('#edit-category').find('option').contains(/beta/i).should('exist');
+
+        // The chip's × removes it and returns it to the dropdown.
+        cy.get('[data-category-select]')
+            .contains('li', 'alpha')
+            .find('button[aria-label^="Remove category"]')
+            .click();
+        cy.get('[data-category-select]').contains('li', 'alpha').should('not.exist');
+        cy.get('#edit-category').find('option').contains(/alpha/i).should('exist');
     });
 
     it('screenshot viewer: arrow keys navigate and Escape closes', () => {


### PR DESCRIPTION
Cypress coverage for the storefront/editor UX fixes in store-template PR (search-clear + tag-style category picker).

## Changes
- **`16-storefront.cy.ts`** — two specs: clearing the header search drops the keyword (the previously filtered-out module returns), and clearing keeps the active status facet. Both use a reload-safe window-stamp helper (`clearHeaderSearchAndWaitReload`, mirrors `17-authoring`'s `saveAndWaitReload`) to wait out the programmatic-submit reload before asserting — `.trigger('search')` isn't tracked as a navigation like a click/{enter}, so a bare assertion would straddle the reload.
- **`17-authoring.cy.ts`** — updated the "lists configured categories" assertion (label → `#edit-category` option, since categories are now a chip/dropdown rather than checkboxes) and added a test: picking a category from the dropdown adds a removable chip and drops it from the options; the chip × restores it.

## Test plan
- Full suite **121/121** green against a fresh stack.