### PR TITLE
refactor: namespace store GraphQL under a single `forge` field

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,11 @@ authenticated users are denied (`GqlAccessDeniedException`). This shapes the API
   branding read by the jahia-store-template chrome: `forgeSettingsLogo` (weakreference to
   a media image) plus footer strings `forgeSettingsCopyright` / `*PrivacyUrl` /
   `*TermsUrl` / `*CookiesUrl` / `*FacebookUrl` / `*LinkedinUrl` / `*TwitterUrl` /
-  `*YoutubeUrl`. Exposed/edited via the `forgeSettings` query + `updateForgeSettings`
-  mutation (shared `ForgeSettingsReader`; `GqlForgeSettings` uses a builder).
+  `*YoutubeUrl`. Exposed/edited via the `forge { settings }` query + `forge { updateSettings }`
+  mutation (shared `ForgeSettingsReader`; `GqlForgeSettings` uses a builder). All store GraphQL
+  operations are namespaced under a single `forge` field on the root Query/Mutation
+  (`ForgeQueryExtension`/`ForgeMutationExtension` → `ForgeQuery`/`ForgeMutation` containers),
+  rather than flat top-level fields.
 
 ## Directory map
 

--- a/src/javascript/CategorySettings/CategorySettings.gql.js
+++ b/src/javascript/CategorySettings/CategorySettings.gql.js
@@ -2,21 +2,23 @@ import {gql} from '@apollo/client';
 
 export const GET_CATEGORY_SETTINGS = gql`
     query ForgeCategorySettings($siteKey: String!) {
-        forgeCategorySettings(siteKey: $siteKey) {
-            siteKey
-            rootCategoryUuid
-            rootCategoryPath
-            rootCategoryDisplayName
-            siteLanguages
-            categories {
-                uuid
-                name
-                displayName
-                titles {
-                    language
-                    title
+        forge {
+            categorySettings(siteKey: $siteKey) {
+                siteKey
+                rootCategoryUuid
+                rootCategoryPath
+                rootCategoryDisplayName
+                siteLanguages
+                categories {
+                    uuid
+                    name
+                    displayName
+                    titles {
+                        language
+                        title
+                    }
+                    usages
                 }
-                usages
             }
         }
     }
@@ -24,13 +26,17 @@ export const GET_CATEGORY_SETTINGS = gql`
 
 export const SET_ROOT_CATEGORY = gql`
     mutation SetRootCategory($siteKey: String!, $rootCategoryUuid: String!) {
-        setRootCategory(siteKey: $siteKey, rootCategoryUuid: $rootCategoryUuid)
+        forge {
+            setRootCategory(siteKey: $siteKey, rootCategoryUuid: $rootCategoryUuid)
+        }
     }
 `;
 
 export const ADD_FORGE_CATEGORY = gql`
     mutation AddForgeCategory($siteKey: String!, $name: String!) {
-        addForgeCategory(siteKey: $siteKey, name: $name)
+        forge {
+            addCategory(siteKey: $siteKey, name: $name)
+        }
     }
 `;
 
@@ -40,12 +46,16 @@ export const UPDATE_FORGE_CATEGORY_TITLES = gql`
         $uuid: String!
         $titles: [InputForgeCategoryTitle!]!
     ) {
-        updateForgeCategoryTitles(siteKey: $siteKey, uuid: $uuid, titles: $titles)
+        forge {
+            updateCategoryTitles(siteKey: $siteKey, uuid: $uuid, titles: $titles)
+        }
     }
 `;
 
 export const DELETE_FORGE_CATEGORY = gql`
     mutation DeleteForgeCategory($siteKey: String!, $uuid: String!) {
-        deleteForgeCategory(siteKey: $siteKey, uuid: $uuid)
+        forge {
+            deleteCategory(siteKey: $siteKey, uuid: $uuid)
+        }
     }
 `;

--- a/src/javascript/CategorySettings/CategorySettings.jsx
+++ b/src/javascript/CategorySettings/CategorySettings.jsx
@@ -53,7 +53,7 @@ export function CategorySettings({siteKey}) {
         );
     }
 
-    const settings = data && data.forgeCategorySettings;
+    const settings = data && data.forge && data.forge.categorySettings;
     if (!settings) {
         return (
             <div className={styles.category_error} role="alert">
@@ -100,10 +100,10 @@ export function CategorySettings({siteKey}) {
             reportSuccess('categories.success.add');
             // Auto-open the editor for the new category so the admin can immediately
             // fill in the per-language titles.
-            const newUuid = addData && addData.addForgeCategory;
+            const newUuid = addData && addData.forge && addData.forge.addCategory;
             if (newUuid) {
                 const refreshed = await refetch();
-                const created = refreshed?.data?.forgeCategorySettings?.categories?.find(c => c.uuid === newUuid);
+                const created = refreshed?.data?.forge?.categorySettings?.categories?.find(c => c.uuid === newUuid);
                 if (created) {
                     openEditor(created);
                 }

--- a/src/javascript/ForgeSettings/ForgeSettings.gql.js
+++ b/src/javascript/ForgeSettings/ForgeSettings.gql.js
@@ -2,22 +2,24 @@ import {gql} from '@apollo/client';
 
 export const GET_FORGE_SETTINGS = gql`
     query ForgeSettings($siteKey: String!) {
-        forgeSettings(siteKey: $siteKey) {
-            siteKey
-            url
-            id
-            user
-            passwordSet
-            logoPath
-            copyright
-            footerLinks {
-                privacyUrl
-                termsUrl
-                cookiesUrl
-                facebookUrl
-                linkedinUrl
-                twitterUrl
-                youtubeUrl
+        forge {
+            settings(siteKey: $siteKey) {
+                siteKey
+                url
+                id
+                user
+                passwordSet
+                logoPath
+                copyright
+                footerLinks {
+                    privacyUrl
+                    termsUrl
+                    cookiesUrl
+                    facebookUrl
+                    linkedinUrl
+                    twitterUrl
+                    youtubeUrl
+                }
             }
         }
     }
@@ -40,41 +42,43 @@ export const UPDATE_FORGE_SETTINGS = gql`
         $twitterUrl: String
         $youtubeUrl: String
     ) {
-        updateForgeSettings(
-            siteKey: $siteKey
-            settings: {
-                url: $url
-                id: $id
-                user: $user
-                password: $password
-                logo: $logo
-                copyright: $copyright
-                footerLinks: {
-                    privacyUrl: $privacyUrl
-                    termsUrl: $termsUrl
-                    cookiesUrl: $cookiesUrl
-                    facebookUrl: $facebookUrl
-                    linkedinUrl: $linkedinUrl
-                    twitterUrl: $twitterUrl
-                    youtubeUrl: $youtubeUrl
+        forge {
+            updateSettings(
+                siteKey: $siteKey
+                settings: {
+                    url: $url
+                    id: $id
+                    user: $user
+                    password: $password
+                    logo: $logo
+                    copyright: $copyright
+                    footerLinks: {
+                        privacyUrl: $privacyUrl
+                        termsUrl: $termsUrl
+                        cookiesUrl: $cookiesUrl
+                        facebookUrl: $facebookUrl
+                        linkedinUrl: $linkedinUrl
+                        twitterUrl: $twitterUrl
+                        youtubeUrl: $youtubeUrl
+                    }
                 }
-            }
-        ) {
-            siteKey
-            url
-            id
-            user
-            passwordSet
-            logoPath
-            copyright
-            footerLinks {
-                privacyUrl
-                termsUrl
-                cookiesUrl
-                facebookUrl
-                linkedinUrl
-                twitterUrl
-                youtubeUrl
+            ) {
+                siteKey
+                url
+                id
+                user
+                passwordSet
+                logoPath
+                copyright
+                footerLinks {
+                    privacyUrl
+                    termsUrl
+                    cookiesUrl
+                    facebookUrl
+                    linkedinUrl
+                    twitterUrl
+                    youtubeUrl
+                }
             }
         }
     }

--- a/src/javascript/ForgeSettings/ForgeSettings.jsx
+++ b/src/javascript/ForgeSettings/ForgeSettings.jsx
@@ -86,8 +86,8 @@ export function ForgeSettings({siteKey}) {
     };
 
     useEffect(() => {
-        if (data && data.forgeSettings) {
-            syncFromSettings(data.forgeSettings);
+        if (data && data.forge && data.forge.settings) {
+            syncFromSettings(data.forge.settings);
         }
     }, [data]);
 
@@ -116,7 +116,7 @@ export function ForgeSettings({siteKey}) {
                     youtubeUrl: footer.youtubeUrl || null
                 }
             });
-            setSaveStatus(result.data && result.data.updateForgeSettings ? 'success' : 'error');
+            setSaveStatus(result.data && result.data.forge && result.data.forge.updateSettings ? 'success' : 'error');
             setPassword('');
         } catch {
             // The failure is surfaced to the user via the 'error' save status; avoid
@@ -126,8 +126,8 @@ export function ForgeSettings({siteKey}) {
     };
 
     const handleCancel = () => {
-        if (data && data.forgeSettings) {
-            syncFromSettings(data.forgeSettings);
+        if (data && data.forge && data.forge.settings) {
+            syncFromSettings(data.forge.settings);
         }
 
         setSaveStatus('cancel');

--- a/src/javascript/ManageRoles/ManageRoles.gql.js
+++ b/src/javascript/ManageRoles/ManageRoles.gql.js
@@ -2,14 +2,16 @@ import {gql} from '@apollo/client';
 
 export const GET_MANAGE_ROLES_SETTINGS = gql`
     query ManageRolesSettings($siteKey: String!) {
-        manageRolesSettings(siteKey: $siteKey) {
-            siteKey
-            roles {
-                role
-                members {
-                    name
-                    type
-                    displayName
+        forge {
+            manageRolesSettings(siteKey: $siteKey) {
+                siteKey
+                roles {
+                    role
+                    members {
+                        name
+                        type
+                        displayName
+                    }
                 }
             }
         }
@@ -22,10 +24,12 @@ export const SEARCH_FORGE_PRINCIPALS = gql`
         $searchTerm: String!
         $type: ForgePrincipalType!
     ) {
-        searchForgePrincipals(siteKey: $siteKey, searchTerm: $searchTerm, type: $type) {
-            name
-            type
-            displayName
+        forge {
+            searchPrincipals(siteKey: $siteKey, searchTerm: $searchTerm, type: $type) {
+                name
+                type
+                displayName
+            }
         }
     }
 `;
@@ -37,12 +41,14 @@ export const GRANT_SITE_ROLE = gql`
         $principalName: String!
         $principalType: ForgePrincipalType!
     ) {
-        grantSiteRole(
-            siteKey: $siteKey
-            role: $role
-            principalName: $principalName
-            principalType: $principalType
-        )
+        forge {
+            grantRole(
+                siteKey: $siteKey
+                role: $role
+                principalName: $principalName
+                principalType: $principalType
+            )
+        }
     }
 `;
 
@@ -53,11 +59,13 @@ export const REVOKE_SITE_ROLE = gql`
         $principalName: String!
         $principalType: ForgePrincipalType!
     ) {
-        revokeSiteRole(
-            siteKey: $siteKey
-            role: $role
-            principalName: $principalName
-            principalType: $principalType
-        )
+        forge {
+            revokeRole(
+                siteKey: $siteKey
+                role: $role
+                principalName: $principalName
+                principalType: $principalType
+            )
+        }
     }
 `;

--- a/src/javascript/ManageRoles/ManageRoles.jsx
+++ b/src/javascript/ManageRoles/ManageRoles.jsx
@@ -112,7 +112,7 @@ export function ManageRoles({siteKey}) {
         );
     }
 
-    const settings = data && data.manageRolesSettings;
+    const settings = data && data.forge && data.forge.manageRolesSettings;
     if (!settings) {
         return <div className={styles.roles_error} role="alert">{t('errors.load.failed')}</div>;
     }
@@ -207,9 +207,9 @@ export function ManageRoles({siteKey}) {
                                         }}
                                     />
                                 </div>
-                                {searchData && searchData.searchForgePrincipals && searchData.searchForgePrincipals.length > 0 ? (
+                                {searchData && searchData.forge && searchData.forge.searchPrincipals && searchData.forge.searchPrincipals.length > 0 ? (
                                     <ul className={styles.roles_search_results}>
-                                        {searchData.searchForgePrincipals.map(p => (
+                                        {searchData.forge.searchPrincipals.map(p => (
                                             <li
                                                 key={`${p.type}:${p.name}`}
                                                 className={styles.roles_search_result}

--- a/src/main/java/org/jahia/modules/forge/graphql/CategorySettingsMutationExtension.java
+++ b/src/main/java/org/jahia/modules/forge/graphql/CategorySettingsMutationExtension.java
@@ -1,13 +1,7 @@
 package org.jahia.modules.forge.graphql;
 
-import graphql.annotations.annotationTypes.GraphQLDescription;
-import graphql.annotations.annotationTypes.GraphQLField;
-import graphql.annotations.annotationTypes.GraphQLName;
-import graphql.annotations.annotationTypes.GraphQLNonNull;
-import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.apache.commons.lang.StringUtils;
 import org.jahia.modules.forge.settings.ForgeSettingsService;
-import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
 import org.jahia.services.content.JCRCallback;
 import org.jahia.services.content.JCRContentUtils;
 import org.jahia.services.content.JCRNodeWrapper;
@@ -20,9 +14,12 @@ import javax.jcr.RepositoryException;
 import java.util.List;
 import java.util.Locale;
 
-@GraphQLTypeExtension(DXGraphQLProvider.Mutation.class)
-@GraphQLName("CategorySettingsMutations")
-@GraphQLDescription("Private App Store category settings mutations")
+/**
+ * Logic holder for the Private App Store category-management write operations. The GraphQL surface
+ * is {@code mutation { forge { setRootCategory / addCategory / updateCategoryTitles / deleteCategory } }}
+ * — see {@link ForgeMutation}, which delegates here. (Formerly a flat {@code @GraphQLTypeExtension}
+ * contributing those mutations straight onto the root Mutation.)
+ */
 public final class CategorySettingsMutationExtension {
 
     private static final String PERMISSION = "siteAdminForgeSettings";
@@ -33,12 +30,7 @@ public final class CategorySettingsMutationExtension {
     private CategorySettingsMutationExtension() {
     }
 
-    @GraphQLField
-    @GraphQLName("setRootCategory")
-    @GraphQLDescription("Set the JCR node configured as the site's root category")
-    public static Boolean setRootCategory(
-            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey,
-            @GraphQLName("rootCategoryUuid") @GraphQLNonNull final String rootCategoryUuid) {
+    public static Boolean setRootCategory(final String siteKey, final String rootCategoryUuid) {
         return execute(siteKey, session -> {
             // Validate the target is an actual category before storing it: the gate runs in a
             // system session that bypasses ACLs, so an unvalidated UUID could point the site's
@@ -54,12 +46,7 @@ public final class CategorySettingsMutationExtension {
         });
     }
 
-    @GraphQLField
-    @GraphQLName("addForgeCategory")
-    @GraphQLDescription("Create a jnt:category node under the site's root category, returning its UUID")
-    public static String addForgeCategory(
-            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey,
-            @GraphQLName("name") @GraphQLNonNull final String name) {
+    public static String addForgeCategory(final String siteKey, final String name) {
         if (StringUtils.isBlank(name)) {
             throw new IllegalArgumentException("Category name must not be blank");
         }
@@ -73,13 +60,8 @@ public final class CategorySettingsMutationExtension {
         });
     }
 
-    @GraphQLField
-    @GraphQLName("updateForgeCategoryTitles")
-    @GraphQLDescription("Set per-language jcr:title on a category. Blank/null title removes the translation.")
-    public static Boolean updateForgeCategoryTitles(
-            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey,
-            @GraphQLName("uuid") @GraphQLNonNull final String uuid,
-            @GraphQLName("titles") @GraphQLNonNull final List<InputCategoryTitle> titles) {
+    public static Boolean updateForgeCategoryTitles(final String siteKey, final String uuid,
+                                                    final List<InputCategoryTitle> titles) {
         return execute(siteKey, session -> {
             // Confine titling to a category within THIS site's root-category subtree
             // (the gate is site-scoped; validate the caller-supplied UUID).
@@ -115,12 +97,7 @@ public final class CategorySettingsMutationExtension {
         localized.save();
     }
 
-    @GraphQLField
-    @GraphQLName("deleteForgeCategory")
-    @GraphQLDescription("Delete a category node by UUID")
-    public static Boolean deleteForgeCategory(
-            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey,
-            @GraphQLName("uuid") @GraphQLNonNull final String uuid) {
+    public static Boolean deleteForgeCategory(final String siteKey, final String uuid) {
         return execute(siteKey, session -> {
             // Confine deletion to a category within THIS site's root-category subtree.
             // The gate authorizes against the site, but the system session bypasses

--- a/src/main/java/org/jahia/modules/forge/graphql/CategorySettingsQueryExtension.java
+++ b/src/main/java/org/jahia/modules/forge/graphql/CategorySettingsQueryExtension.java
@@ -1,13 +1,7 @@
 package org.jahia.modules.forge.graphql;
 
-import graphql.annotations.annotationTypes.GraphQLDescription;
-import graphql.annotations.annotationTypes.GraphQLField;
-import graphql.annotations.annotationTypes.GraphQLName;
-import graphql.annotations.annotationTypes.GraphQLNonNull;
-import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.apache.commons.lang.StringUtils;
 import org.apache.jackrabbit.core.fs.FileSystem;
-import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
 import org.jahia.services.content.JCRCallback;
 import org.jahia.services.content.JCRNodeIteratorWrapper;
 import org.jahia.services.content.JCRNodeWrapper;
@@ -31,9 +25,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-@GraphQLTypeExtension(DXGraphQLProvider.Query.class)
-@GraphQLName("CategorySettingsQueries")
-@GraphQLDescription("Private App Store category settings queries")
+/**
+ * Logic holder for the Private App Store "read category settings" operation. The GraphQL surface
+ * is {@code query { forge { categorySettings(siteKey: "...") } }} — see {@link ForgeQuery}, which
+ * delegates here. (Formerly a flat {@code @GraphQLTypeExtension} contributing
+ * {@code forgeCategorySettings} straight onto the root Query.)
+ */
 public final class CategorySettingsQueryExtension {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CategorySettingsQueryExtension.class);
@@ -47,11 +44,7 @@ public final class CategorySettingsQueryExtension {
     private CategorySettingsQueryExtension() {
     }
 
-    @GraphQLField
-    @GraphQLName("forgeCategorySettings")
-    @GraphQLDescription("Read the forge category settings for a site")
-    public static GqlForgeCategorySettings getForgeCategorySettings(
-            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey) {
+    public static GqlForgeCategorySettings getForgeCategorySettings(final String siteKey) {
         ForgeSettingsMutationExtension.validateSiteKey(siteKey);
         try {
             return JCRTemplate.getInstance().doExecuteWithSystemSession(new JCRCallback<GqlForgeCategorySettings>() {

--- a/src/main/java/org/jahia/modules/forge/graphql/ForgeMutation.java
+++ b/src/main/java/org/jahia/modules/forge/graphql/ForgeMutation.java
@@ -1,0 +1,91 @@
+package org.jahia.modules.forge.graphql;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+import graphql.annotations.annotationTypes.GraphQLNonNull;
+
+import java.util.List;
+
+/**
+ * Write side of the Private App Store GraphQL surface, reached through the single
+ * {@code forge} field on the root Mutation (see {@link ForgeMutationExtension}):
+ * {@code mutation { forge { updateSettings(siteKey: "...", settings: {...}) { ... } } }}.
+ *
+ * <p>Grouping every store mutation under one namespace replaces the previous set of fields
+ * (updateForgeSettings, setRootCategory, addForgeCategory, ...) that flattened straight onto
+ * the global Mutation type. Each field here delegates to the focused logic holder for its
+ * concern; the authorization and validation live there.
+ */
+@GraphQLName("ForgeMutation")
+@GraphQLDescription("Private App Store mutations")
+public class ForgeMutation {
+
+    @GraphQLField
+    @GraphQLName("updateSettings")
+    @GraphQLDescription("Create or update the forge settings for a site")
+    public GqlForgeSettings updateSettings(
+            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey,
+            @GraphQLName("settings") @GraphQLNonNull @GraphQLDescription("Connection + branding fields") final ForgeSettingsInput settings) {
+        return ForgeSettingsMutationExtension.updateForgeSettings(siteKey, settings);
+    }
+
+    @GraphQLField
+    @GraphQLName("setRootCategory")
+    @GraphQLDescription("Set the JCR node configured as the site's root category")
+    public Boolean setRootCategory(
+            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey,
+            @GraphQLName("rootCategoryUuid") @GraphQLNonNull final String rootCategoryUuid) {
+        return CategorySettingsMutationExtension.setRootCategory(siteKey, rootCategoryUuid);
+    }
+
+    @GraphQLField
+    @GraphQLName("addCategory")
+    @GraphQLDescription("Create a jnt:category node under the site's root category, returning its UUID")
+    public String addCategory(
+            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey,
+            @GraphQLName("name") @GraphQLNonNull final String name) {
+        return CategorySettingsMutationExtension.addForgeCategory(siteKey, name);
+    }
+
+    @GraphQLField
+    @GraphQLName("updateCategoryTitles")
+    @GraphQLDescription("Set per-language jcr:title on a category. Blank/null title removes the translation.")
+    public Boolean updateCategoryTitles(
+            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey,
+            @GraphQLName("uuid") @GraphQLNonNull final String uuid,
+            @GraphQLName("titles") @GraphQLNonNull final List<InputCategoryTitle> titles) {
+        return CategorySettingsMutationExtension.updateForgeCategoryTitles(siteKey, uuid, titles);
+    }
+
+    @GraphQLField
+    @GraphQLName("deleteCategory")
+    @GraphQLDescription("Delete a category node by UUID")
+    public Boolean deleteCategory(
+            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey,
+            @GraphQLName("uuid") @GraphQLNonNull final String uuid) {
+        return CategorySettingsMutationExtension.deleteForgeCategory(siteKey, uuid);
+    }
+
+    @GraphQLField
+    @GraphQLName("grantRole")
+    @GraphQLDescription("Grant a role to a principal on the site node")
+    public Boolean grantRole(
+            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey,
+            @GraphQLName("role") @GraphQLNonNull final String role,
+            @GraphQLName("principalName") @GraphQLNonNull final String principalName,
+            @GraphQLName("principalType") @GraphQLNonNull final PrincipalType principalType) {
+        return ManageRolesMutationExtension.grantSiteRole(siteKey, role, principalName, principalType);
+    }
+
+    @GraphQLField
+    @GraphQLName("revokeRole")
+    @GraphQLDescription("Revoke a single role from a principal on the site node. Leaves other roles untouched.")
+    public Boolean revokeRole(
+            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey,
+            @GraphQLName("role") @GraphQLNonNull final String role,
+            @GraphQLName("principalName") @GraphQLNonNull final String principalName,
+            @GraphQLName("principalType") @GraphQLNonNull final PrincipalType principalType) {
+        return ManageRolesMutationExtension.revokeSiteRole(siteKey, role, principalName, principalType);
+    }
+}

--- a/src/main/java/org/jahia/modules/forge/graphql/ForgeMutationExtension.java
+++ b/src/main/java/org/jahia/modules/forge/graphql/ForgeMutationExtension.java
@@ -1,0 +1,32 @@
+package org.jahia.modules.forge.graphql;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+import graphql.annotations.annotationTypes.GraphQLTypeExtension;
+import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
+
+/**
+ * Adds the single {@code forge} namespace field to the root Mutation, under which every Private
+ * App Store write operation lives ({@code mutation { forge { updateSettings(...) } }}).
+ *
+ * <p>This replaces the earlier flat fields (updateForgeSettings, setRootCategory,
+ * addForgeCategory, ...) that each extended the global Mutation type and polluted its top level.
+ * The bundle's {@code DXGraphQLExtensionsProvider} auto-registers any {@code @GraphQLTypeExtension}
+ * class, so adding this one and dropping the annotation from the old extensions is all that is
+ * required.
+ */
+@GraphQLTypeExtension(DXGraphQLProvider.Mutation.class)
+@GraphQLDescription("Private App Store mutation namespace")
+public final class ForgeMutationExtension {
+
+    private ForgeMutationExtension() {
+    }
+
+    @GraphQLField
+    @GraphQLName("forge")
+    @GraphQLDescription("Private App Store mutations")
+    public static ForgeMutation forge() {
+        return new ForgeMutation();
+    }
+}

--- a/src/main/java/org/jahia/modules/forge/graphql/ForgeQuery.java
+++ b/src/main/java/org/jahia/modules/forge/graphql/ForgeQuery.java
@@ -1,0 +1,57 @@
+package org.jahia.modules.forge.graphql;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+import graphql.annotations.annotationTypes.GraphQLNonNull;
+
+import java.util.List;
+
+/**
+ * Read side of the Private App Store GraphQL surface, reached through the single
+ * {@code forge} field on the root Query (see {@link ForgeQueryExtension}):
+ * {@code query { forge { settings(siteKey: "...") { ... } } }}.
+ *
+ * <p>Grouping every store query under one namespace replaces the previous set of fields
+ * (forgeSettings, forgeCategorySettings, manageRolesSettings, searchForgePrincipals) that
+ * flattened straight onto the global Query type. Each field here delegates to the focused
+ * logic holder for its concern; the authorization and validation live there.
+ */
+@GraphQLName("ForgeQuery")
+@GraphQLDescription("Private App Store queries")
+public class ForgeQuery {
+
+    @GraphQLField
+    @GraphQLName("settings")
+    @GraphQLDescription("Read the forge settings for a site")
+    public GqlForgeSettings settings(
+            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey) {
+        return ForgeSettingsQueryExtension.getForgeSettings(siteKey);
+    }
+
+    @GraphQLField
+    @GraphQLName("categorySettings")
+    @GraphQLDescription("Read the forge category settings for a site")
+    public GqlForgeCategorySettings categorySettings(
+            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey) {
+        return CategorySettingsQueryExtension.getForgeCategorySettings(siteKey);
+    }
+
+    @GraphQLField
+    @GraphQLName("manageRolesSettings")
+    @GraphQLDescription("Read the role-management settings for a site")
+    public GqlManageRolesSettings manageRolesSettings(
+            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey) {
+        return ManageRolesQueryExtension.getManageRolesSettings(siteKey);
+    }
+
+    @GraphQLField
+    @GraphQLName("searchPrincipals")
+    @GraphQLDescription("Find users or groups whose name contains the given term (case-insensitive)")
+    public List<GqlPrincipal> searchPrincipals(
+            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey,
+            @GraphQLName("searchTerm") @GraphQLNonNull final String searchTerm,
+            @GraphQLName("type") @GraphQLNonNull final PrincipalType type) {
+        return ManageRolesQueryExtension.searchForgePrincipals(siteKey, searchTerm, type);
+    }
+}

--- a/src/main/java/org/jahia/modules/forge/graphql/ForgeQueryExtension.java
+++ b/src/main/java/org/jahia/modules/forge/graphql/ForgeQueryExtension.java
@@ -1,0 +1,32 @@
+package org.jahia.modules.forge.graphql;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+import graphql.annotations.annotationTypes.GraphQLTypeExtension;
+import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
+
+/**
+ * Adds the single {@code forge} namespace field to the root Query, under which every Private
+ * App Store read operation lives ({@code query { forge { settings(...) } }}).
+ *
+ * <p>This replaces the earlier flat fields (forgeSettings, forgeCategorySettings,
+ * manageRolesSettings, searchForgePrincipals) that each extended the global Query type and
+ * polluted its top level. The bundle's {@code DXGraphQLExtensionsProvider} auto-registers any
+ * {@code @GraphQLTypeExtension} class, so adding this one and dropping the annotation from the
+ * old extensions is all that is required.
+ */
+@GraphQLTypeExtension(DXGraphQLProvider.Query.class)
+@GraphQLDescription("Private App Store query namespace")
+public final class ForgeQueryExtension {
+
+    private ForgeQueryExtension() {
+    }
+
+    @GraphQLField
+    @GraphQLName("forge")
+    @GraphQLDescription("Private App Store queries")
+    public static ForgeQuery forge() {
+        return new ForgeQuery();
+    }
+}

--- a/src/main/java/org/jahia/modules/forge/graphql/ForgeSettingsMutationExtension.java
+++ b/src/main/java/org/jahia/modules/forge/graphql/ForgeSettingsMutationExtension.java
@@ -1,14 +1,8 @@
 package org.jahia.modules.forge.graphql;
 
-import graphql.annotations.annotationTypes.GraphQLDescription;
-import graphql.annotations.annotationTypes.GraphQLField;
-import graphql.annotations.annotationTypes.GraphQLName;
-import graphql.annotations.annotationTypes.GraphQLNonNull;
-import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.apache.jackrabbit.core.fs.FileSystem;
 import org.jahia.modules.forge.settings.ForgeSettings;
 import org.jahia.modules.forge.settings.ForgeSettingsService;
-import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
 import org.jahia.osgi.BundleUtils;
 import org.jahia.services.cache.CacheHelper;
 import org.jahia.services.content.JCRSessionFactory;
@@ -19,9 +13,13 @@ import javax.jcr.AccessDeniedException;
 import javax.jcr.RepositoryException;
 import java.util.regex.Pattern;
 
-@GraphQLTypeExtension(DXGraphQLProvider.Mutation.class)
-@GraphQLName("ForgeSettingsMutations")
-@GraphQLDescription("Private App Store forge settings mutations")
+/**
+ * Logic holder for the Private App Store "update forge settings" operation, plus the shared
+ * {@link #validateSiteKey(String)} and {@link #service()} helpers reused by the other forge
+ * logic holders. The GraphQL surface is {@code mutation { forge { updateSettings(...) } }} —
+ * see {@link ForgeMutation}, which delegates here. (Formerly a flat {@code @GraphQLTypeExtension}
+ * contributing {@code updateForgeSettings} straight onto the root Mutation.)
+ */
 public final class ForgeSettingsMutationExtension {
 
     private static final String PERMISSION = "siteAdminForgeSettings";
@@ -32,12 +30,7 @@ public final class ForgeSettingsMutationExtension {
     private ForgeSettingsMutationExtension() {
     }
 
-    @GraphQLField
-    @GraphQLName("updateForgeSettings")
-    @GraphQLDescription("Create or update the forge settings for a site")
-    public static GqlForgeSettings updateForgeSettings(
-            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey,
-            @GraphQLName("settings") @GraphQLNonNull @GraphQLDescription("Connection + branding fields") final ForgeSettingsInput settings) {
+    public static GqlForgeSettings updateForgeSettings(final String siteKey, final ForgeSettingsInput settings) {
         validateSiteKey(siteKey);
         final String sitePath = SITES_PATH + siteKey;
         try {

--- a/src/main/java/org/jahia/modules/forge/graphql/ForgeSettingsQueryExtension.java
+++ b/src/main/java/org/jahia/modules/forge/graphql/ForgeSettingsQueryExtension.java
@@ -1,12 +1,6 @@
 package org.jahia.modules.forge.graphql;
 
-import graphql.annotations.annotationTypes.GraphQLDescription;
-import graphql.annotations.annotationTypes.GraphQLField;
-import graphql.annotations.annotationTypes.GraphQLName;
-import graphql.annotations.annotationTypes.GraphQLNonNull;
-import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.apache.jackrabbit.core.fs.FileSystem;
-import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
 import org.jahia.services.content.JCRSessionFactory;
 import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.services.sites.JahiaSitesService;
@@ -16,9 +10,12 @@ import org.slf4j.LoggerFactory;
 import javax.jcr.AccessDeniedException;
 import javax.jcr.RepositoryException;
 
-@GraphQLTypeExtension(DXGraphQLProvider.Query.class)
-@GraphQLName("ForgeSettingsQueries")
-@GraphQLDescription("Private App Store forge settings queries")
+/**
+ * Logic holder for the Private App Store "read forge settings" operation. The GraphQL surface is
+ * {@code query { forge { settings(siteKey: "...") } }} — see {@link ForgeQuery}, which delegates
+ * here. (Formerly a flat {@code @GraphQLTypeExtension} contributing {@code forgeSettings} straight
+ * onto the root Query.)
+ */
 public final class ForgeSettingsQueryExtension {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ForgeSettingsQueryExtension.class);
@@ -28,11 +25,7 @@ public final class ForgeSettingsQueryExtension {
     private ForgeSettingsQueryExtension() {
     }
 
-    @GraphQLField
-    @GraphQLName("forgeSettings")
-    @GraphQLDescription("Read the forge settings for a site")
-    public static GqlForgeSettings getForgeSettings(
-            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey) {
+    public static GqlForgeSettings getForgeSettings(final String siteKey) {
         ForgeSettingsMutationExtension.validateSiteKey(siteKey);
         final String sitePath = SITES_PATH + siteKey;
         try {

--- a/src/main/java/org/jahia/modules/forge/graphql/ManageRolesMutationExtension.java
+++ b/src/main/java/org/jahia/modules/forge/graphql/ManageRolesMutationExtension.java
@@ -1,12 +1,6 @@
 package org.jahia.modules.forge.graphql;
 
-import graphql.annotations.annotationTypes.GraphQLDescription;
-import graphql.annotations.annotationTypes.GraphQLField;
-import graphql.annotations.annotationTypes.GraphQLName;
-import graphql.annotations.annotationTypes.GraphQLNonNull;
-import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.apache.jackrabbit.core.fs.FileSystem;
-import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
 import org.jahia.services.content.JCRCallback;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.sites.JahiaSitesService;
@@ -16,9 +10,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-@GraphQLTypeExtension(DXGraphQLProvider.Mutation.class)
-@GraphQLName("ManageRolesMutations")
-@GraphQLDescription("Private App Store role-management mutations")
+/**
+ * Logic holder for the Private App Store role-management write operations. The GraphQL surface is
+ * {@code mutation { forge { grantRole / revokeRole } }} — see {@link ForgeMutation}, which delegates
+ * here. (Formerly a flat {@code @GraphQLTypeExtension} contributing {@code grantSiteRole} and
+ * {@code revokeSiteRole} straight onto the root Mutation.)
+ */
 public final class ManageRolesMutationExtension {
 
     private static final String PERMISSION = "siteAdminForgeSettings";
@@ -28,14 +25,8 @@ public final class ManageRolesMutationExtension {
     private ManageRolesMutationExtension() {
     }
 
-    @GraphQLField
-    @GraphQLName("grantSiteRole")
-    @GraphQLDescription("Grant a role to a principal on the site node")
-    public static Boolean grantSiteRole(
-            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey,
-            @GraphQLName("role") @GraphQLNonNull final String role,
-            @GraphQLName("principalName") @GraphQLNonNull final String principalName,
-            @GraphQLName("principalType") @GraphQLNonNull final PrincipalType principalType) {
+    public static Boolean grantSiteRole(final String siteKey, final String role,
+                                        final String principalName, final PrincipalType principalType) {
         // Only the store-managed roles may be granted through this gate. Without this an admin
         // with siteAdminForgeSettings could pass an arbitrary role name and create ACL entries
         // beyond the store's intended set (SECURITY-571). The allowlist is the same set the
@@ -52,14 +43,8 @@ public final class ManageRolesMutationExtension {
         });
     }
 
-    @GraphQLField
-    @GraphQLName("revokeSiteRole")
-    @GraphQLDescription("Revoke a single role from a principal on the site node. Leaves other roles untouched.")
-    public static Boolean revokeSiteRole(
-            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey,
-            @GraphQLName("role") @GraphQLNonNull final String role,
-            @GraphQLName("principalName") @GraphQLNonNull final String principalName,
-            @GraphQLName("principalType") @GraphQLNonNull final PrincipalType principalType) {
+    public static Boolean revokeSiteRole(final String siteKey, final String role,
+                                         final String principalName, final PrincipalType principalType) {
         // Same allowlist as grantSiteRole: this gate manages only the store roles, so it must
         // never revoke a non-store role (e.g. strip site-administrator from a principal). Without
         // this a store admin could downgrade arbitrary site grants. (SECURITY-571 review NEW-1)
@@ -93,7 +78,7 @@ public final class ManageRolesMutationExtension {
      * minus the one being revoked. Inherited entries are intentionally excluded —
      * they can only be edited at their source node.
      */
-    private static Set<String> directGrantsExcluding(List<String[]> grants, String sitePath, String roleToRevoke) {
+    static Set<String> directGrantsExcluding(List<String[]> grants, String sitePath, String roleToRevoke) {
         final Set<String> remaining = new HashSet<>();
         for (String[] grant : grants) {
             if (isDirectGrantForOtherRole(grant, sitePath, roleToRevoke)) {

--- a/src/main/java/org/jahia/modules/forge/graphql/ManageRolesQueryExtension.java
+++ b/src/main/java/org/jahia/modules/forge/graphql/ManageRolesQueryExtension.java
@@ -1,13 +1,7 @@
 package org.jahia.modules.forge.graphql;
 
-import graphql.annotations.annotationTypes.GraphQLDescription;
-import graphql.annotations.annotationTypes.GraphQLField;
-import graphql.annotations.annotationTypes.GraphQLName;
-import graphql.annotations.annotationTypes.GraphQLNonNull;
-import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.apache.commons.lang.StringUtils;
 import org.apache.jackrabbit.core.fs.FileSystem;
-import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
 import org.jahia.services.content.JCRContentUtils;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.JCRSessionFactory;
@@ -28,9 +22,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-@GraphQLTypeExtension(DXGraphQLProvider.Query.class)
-@GraphQLName("ManageRolesQueries")
-@GraphQLDescription("Private App Store role-management queries")
+/**
+ * Logic holder for the Private App Store role-management read operations. The GraphQL surface is
+ * {@code query { forge { manageRolesSettings / searchPrincipals } }} — see {@link ForgeQuery},
+ * which delegates here. (Formerly a flat {@code @GraphQLTypeExtension} contributing
+ * {@code manageRolesSettings} and {@code searchForgePrincipals} straight onto the root Query.)
+ */
 public final class ManageRolesQueryExtension {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ManageRolesQueryExtension.class);
@@ -51,11 +48,7 @@ public final class ManageRolesQueryExtension {
     private ManageRolesQueryExtension() {
     }
 
-    @GraphQLField
-    @GraphQLName("manageRolesSettings")
-    @GraphQLDescription("Read the role-management settings for a site")
-    public static GqlManageRolesSettings getManageRolesSettings(
-            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey) {
+    public static GqlManageRolesSettings getManageRolesSettings(final String siteKey) {
         ForgeSettingsMutationExtension.validateSiteKey(siteKey);
         try {
             return JCRTemplate.getInstance().doExecuteWithSystemSession(session ->
@@ -131,13 +124,8 @@ public final class ManageRolesQueryExtension {
                 && FORGE_ROLES.contains(grant[2]);
     }
 
-    @GraphQLField
-    @GraphQLName("searchForgePrincipals")
-    @GraphQLDescription("Find users or groups whose name contains the given term (case-insensitive)")
-    public static List<GqlPrincipal> searchForgePrincipals(
-            @GraphQLName("siteKey") @GraphQLNonNull final String siteKey,
-            @GraphQLName("searchTerm") @GraphQLNonNull final String searchTerm,
-            @GraphQLName("type") @GraphQLNonNull final PrincipalType type) {
+    public static List<GqlPrincipal> searchForgePrincipals(final String siteKey, final String searchTerm,
+                                                           final PrincipalType type) {
         ForgeSettingsMutationExtension.validateSiteKey(siteKey);
         if (StringUtils.isBlank(searchTerm)) {
             return Collections.emptyList();

--- a/tests/cypress/e2e/05-forgeSettingsAdmin.cy.ts
+++ b/tests/cypress/e2e/05-forgeSettingsAdmin.cy.ts
@@ -37,7 +37,7 @@ describe('Forge settings admin (React + GraphQL)', () => {
 
     it('returns an empty settings payload before any save', () => {
         cy.apollo({query: getForgeSettings, variables: {siteKey}})
-            .its('data.forgeSettings')
+            .its('data.forge.settings')
             .should((settings: { siteKey: string; url: string | null; passwordSet: boolean }) => {
                 expect(settings.siteKey).to.equal(siteKey);
                 expect(settings.url).to.be.null;
@@ -56,14 +56,14 @@ describe('Forge settings admin (React + GraphQL)', () => {
                 password: 'p@ssw0rd'
             }
         })
-            .its('data.updateForgeSettings')
+            .its('data.forge.updateSettings')
             .should((settings: { url: string; passwordSet: boolean }) => {
                 expect(settings.url).to.equal('https://store.example.com');
                 expect(settings.passwordSet).to.equal(true);
             });
 
         cy.apollo({query: getForgeSettings, variables: {siteKey}})
-            .its('data.forgeSettings')
+            .its('data.forge.settings')
             .should((settings: { url: string; id: string; user: string; passwordSet: boolean }) => {
                 expect(settings.url).to.equal('https://store.example.com');
                 expect(settings.id).to.equal('forge-1');
@@ -83,7 +83,7 @@ describe('Forge settings admin (React + GraphQL)', () => {
                 password: null
             }
         })
-            .its('data.updateForgeSettings.passwordSet')
+            .its('data.forge.updateSettings.passwordSet')
             .should('equal', true);
     });
 

--- a/tests/cypress/e2e/06-categorySettingsAdmin.cy.ts
+++ b/tests/cypress/e2e/06-categorySettingsAdmin.cy.ts
@@ -71,7 +71,7 @@ describe('Category settings admin (React + GraphQL)', () => {
 
     it('returns empty settings before any root is configured', () => {
         cy.apollo({query: getCategorySettings, variables: {siteKey}})
-            .its('data.forgeCategorySettings')
+            .its('data.forge.categorySettings')
             .should((s: { rootCategoryUuid: string | null; siteLanguages: string[]; categories: unknown[] }) => {
                 expect(s.rootCategoryUuid).to.be.null;
                 expect(s.siteLanguages).to.include.members(['en', 'fr']);
@@ -86,7 +86,7 @@ describe('Category settings admin (React + GraphQL)', () => {
         });
 
         cy.apollo({query: getCategorySettings, variables: {siteKey}})
-            .its('data.forgeCategorySettings')
+            .its('data.forge.categorySettings')
             .should((s: { rootCategoryUuid: string; rootCategoryPath: string }) => {
                 expect(s.rootCategoryUuid).to.equal(rootCategoryUuid);
                 expect(s.rootCategoryPath).to.equal(`/sites/${siteKey}/${rootCategoryName}`);
@@ -100,7 +100,7 @@ describe('Category settings admin (React + GraphQL)', () => {
             mutation: addForgeCategory,
             variables: {siteKey, name: 'portlets'}
         })
-            .its('data.addForgeCategory')
+            .its('data.forge.addCategory')
             .should((uuid: string) => {
                 expect(uuid).to.be.a('string').and.not.empty;
                 createdUuid = uuid;
@@ -120,7 +120,7 @@ describe('Category settings admin (React + GraphQL)', () => {
             });
 
             cy.apollo({query: getCategorySettings, variables: {siteKey}})
-                .its('data.forgeCategorySettings.categories')
+                .its('data.forge.categorySettings.categories')
                 .should((categories: Array<{ uuid: string; titles: Array<{ language: string; title: string }> }>) => {
                     const created = categories.find(c => c.uuid === createdUuid);
                     expect(created, 'created category present').to.not.be.undefined;
@@ -135,7 +135,7 @@ describe('Category settings admin (React + GraphQL)', () => {
             });
 
             cy.apollo({query: getCategorySettings, variables: {siteKey}})
-                .its('data.forgeCategorySettings.categories')
+                .its('data.forge.categorySettings.categories')
                 .should('have.length', 0);
         });
     });
@@ -157,10 +157,10 @@ describe('Category settings admin (React + GraphQL)', () => {
         cy.then(() => {
             // DeleteForgeCategory must be REJECTED. cy.apollo catches GraphQL errors and
             // yields the ApolloError (it does not throw), so a successful call would carry
-            // data.deleteForgeCategory; a rejected one carries graphQLErrors and no data.
+            // data.forge.deleteCategory; a rejected one carries graphQLErrors and no data.
             cy.apollo({mutation: deleteForgeCategory, variables: {siteKey, uuid: outsiderUuid}}).then(r => {
                 const res = r as {data?: {deleteForgeCategory?: boolean}; graphQLErrors?: unknown[]};
-                expect(res.data?.deleteForgeCategory, 'no deletion performed').to.not.equal(true);
+                expect(res.data?.forge?.deleteCategory, 'no deletion performed').to.not.equal(true);
                 expect(res.graphQLErrors, 'rejected with a GraphQL error').to.exist;
             });
 

--- a/tests/cypress/e2e/07-manageRolesAdmin.cy.ts
+++ b/tests/cypress/e2e/07-manageRolesAdmin.cy.ts
@@ -43,7 +43,7 @@ describe('Manage roles admin (React + GraphQL)', () => {
 
     it('returns the curated role list with no direct grants on a fresh site', () => {
         cy.apollo({query: getManageRolesSettings, variables: {siteKey}})
-            .its('data.manageRolesSettings')
+            .its('data.forge.manageRolesSettings')
             .should((s: { roles: Array<{ role: string; members: unknown[] }> }) => {
                 const roleNames = s.roles.map(r => r.role);
                 expect(roleNames).to.deep.equal(['store-administrator', 'store-developer', 'reader']);
@@ -56,7 +56,7 @@ describe('Manage roles admin (React + GraphQL)', () => {
             query: searchForgePrincipals,
             variables: {siteKey, searchTerm: rootPrincipal, type: 'USER'}
         })
-            .its('data.searchForgePrincipals')
+            .its('data.forge.searchPrincipals')
             .should((results: Array<{ name: string; type: string }>) => {
                 expect(results.length).to.be.greaterThan(0);
                 expect(results.some(p => p.name === rootPrincipal && p.type === 'USER')).to.be.true;
@@ -73,11 +73,11 @@ describe('Manage roles admin (React + GraphQL)', () => {
                 principalType: 'USER'
             }
         })
-            .its('data.grantSiteRole')
+            .its('data.forge.grantRole')
             .should('equal', true);
 
         cy.apollo({query: getManageRolesSettings, variables: {siteKey}})
-            .its('data.manageRolesSettings.roles')
+            .its('data.forge.manageRolesSettings.roles')
             .should((roles: Array<{ role: string; members: Array<{ name: string; type: string }> }>) => {
                 const admin = roles.find(r => r.role === 'store-administrator');
                 expect(admin, 'store-administrator role present').to.not.be.undefined;
@@ -93,11 +93,11 @@ describe('Manage roles admin (React + GraphQL)', () => {
                 principalType: 'USER'
             }
         })
-            .its('data.revokeSiteRole')
+            .its('data.forge.revokeRole')
             .should('equal', true);
 
         cy.apollo({query: getManageRolesSettings, variables: {siteKey}})
-            .its('data.manageRolesSettings.roles')
+            .its('data.forge.manageRolesSettings.roles')
             .should((roles: Array<{ role: string; members: unknown[] }>) => {
                 const admin = roles.find(r => r.role === 'store-administrator');
                 expect(admin!.members).to.have.length(0);

--- a/tests/cypress/e2e/08-forgeSettingsUI.cy.ts
+++ b/tests/cypress/e2e/08-forgeSettingsUI.cy.ts
@@ -53,7 +53,7 @@ describe('Forge settings — live UI', () => {
         cy.contains(/success|updated|saved/i, {timeout: 15000}).should('be.visible');
 
         cy.apollo({query: getForgeSettings, variables: {siteKey}})
-            .its('data.forgeSettings')
+            .its('data.forge.settings')
             .should((s: { url: string; id: string; user: string; passwordSet: boolean }) => {
                 expect(s.url).to.equal('https://store.example.com');
                 expect(s.id).to.equal('forge-ui-1');

--- a/tests/cypress/e2e/09-manageRolesUI.cy.ts
+++ b/tests/cypress/e2e/09-manageRolesUI.cy.ts
@@ -72,7 +72,7 @@ describe('Manage roles — live UI', () => {
             .should('be.visible');
 
         cy.apollo({query: getManageRolesSettings, variables: {siteKey}})
-            .its('data.manageRolesSettings.roles')
+            .its('data.forge.manageRolesSettings.roles')
             .should((roles: Array<{ role: string; members: Array<{ name: string }> }>) => {
                 const admin = roles.find(r => r.role === 'store-administrator');
                 expect(admin, 'store-administrator role present').to.not.be.undefined;

--- a/tests/cypress/e2e/10-categorySettingsUI.cy.ts
+++ b/tests/cypress/e2e/10-categorySettingsUI.cy.ts
@@ -103,7 +103,7 @@ describe('Category settings — live UI', () => {
             });
 
         cy.apollo({query: getCategorySettings, variables: {siteKey}, fetchPolicy: 'no-cache'})
-            .its('data.forgeCategorySettings.categories')
+            .its('data.forge.categorySettings.categories')
             .should((cats: Array<{ titles: Array<{ language: string; title: string }> }>) => {
                 expect(cats).to.have.length(1);
                 const titles = Object.fromEntries(cats[0].titles.map(t => [t.language, t.title]));

--- a/tests/cypress/fixtures/graphql/mutation/addForgeCategory.graphql
+++ b/tests/cypress/fixtures/graphql/mutation/addForgeCategory.graphql
@@ -1,3 +1,5 @@
 mutation AddForgeCategory($siteKey: String!, $name: String!) {
-    addForgeCategory(siteKey: $siteKey, name: $name)
+    forge {
+        addCategory(siteKey: $siteKey, name: $name)
+    }
 }

--- a/tests/cypress/fixtures/graphql/mutation/deleteForgeCategory.graphql
+++ b/tests/cypress/fixtures/graphql/mutation/deleteForgeCategory.graphql
@@ -1,3 +1,5 @@
 mutation DeleteForgeCategory($siteKey: String!, $uuid: String!) {
-    deleteForgeCategory(siteKey: $siteKey, uuid: $uuid)
+    forge {
+        deleteCategory(siteKey: $siteKey, uuid: $uuid)
+    }
 }

--- a/tests/cypress/fixtures/graphql/mutation/grantSiteRole.graphql
+++ b/tests/cypress/fixtures/graphql/mutation/grantSiteRole.graphql
@@ -4,10 +4,12 @@ mutation GrantSiteRole(
     $principalName: String!
     $principalType: ForgePrincipalType!
 ) {
-    grantSiteRole(
-        siteKey: $siteKey
-        role: $role
-        principalName: $principalName
-        principalType: $principalType
-    )
+    forge {
+        grantRole(
+            siteKey: $siteKey
+            role: $role
+            principalName: $principalName
+            principalType: $principalType
+        )
+    }
 }

--- a/tests/cypress/fixtures/graphql/mutation/revokeSiteRole.graphql
+++ b/tests/cypress/fixtures/graphql/mutation/revokeSiteRole.graphql
@@ -4,10 +4,12 @@ mutation RevokeSiteRole(
     $principalName: String!
     $principalType: ForgePrincipalType!
 ) {
-    revokeSiteRole(
-        siteKey: $siteKey
-        role: $role
-        principalName: $principalName
-        principalType: $principalType
-    )
+    forge {
+        revokeRole(
+            siteKey: $siteKey
+            role: $role
+            principalName: $principalName
+            principalType: $principalType
+        )
+    }
 }

--- a/tests/cypress/fixtures/graphql/mutation/setRootCategory.graphql
+++ b/tests/cypress/fixtures/graphql/mutation/setRootCategory.graphql
@@ -1,3 +1,5 @@
 mutation SetRootCategory($siteKey: String!, $rootCategoryUuid: String!) {
-    setRootCategory(siteKey: $siteKey, rootCategoryUuid: $rootCategoryUuid)
+    forge {
+        setRootCategory(siteKey: $siteKey, rootCategoryUuid: $rootCategoryUuid)
+    }
 }

--- a/tests/cypress/fixtures/graphql/mutation/updateForgeBranding.graphql
+++ b/tests/cypress/fixtures/graphql/mutation/updateForgeBranding.graphql
@@ -4,12 +4,14 @@ mutation UpdateForgeBranding(
     $copyright: String
     $privacyUrl: String
 ) {
-    updateForgeSettings(siteKey: $siteKey, settings: {logo: $logo, copyright: $copyright, footerLinks: {privacyUrl: $privacyUrl}}) {
-        siteKey
-        copyright
-        footerLinks {
-            privacyUrl
+    forge {
+        updateSettings(siteKey: $siteKey, settings: {logo: $logo, copyright: $copyright, footerLinks: {privacyUrl: $privacyUrl}}) {
+            siteKey
+            copyright
+            footerLinks {
+                privacyUrl
+            }
+            logoPath
         }
-        logoPath
     }
 }

--- a/tests/cypress/fixtures/graphql/mutation/updateForgeCategoryTitles.graphql
+++ b/tests/cypress/fixtures/graphql/mutation/updateForgeCategoryTitles.graphql
@@ -3,5 +3,7 @@ mutation UpdateForgeCategoryTitles(
     $uuid: String!
     $titles: [InputForgeCategoryTitle!]!
 ) {
-    updateForgeCategoryTitles(siteKey: $siteKey, uuid: $uuid, titles: $titles)
+    forge {
+        updateCategoryTitles(siteKey: $siteKey, uuid: $uuid, titles: $titles)
+    }
 }

--- a/tests/cypress/fixtures/graphql/mutation/updateForgeSettings.graphql
+++ b/tests/cypress/fixtures/graphql/mutation/updateForgeSettings.graphql
@@ -5,14 +5,16 @@ mutation UpdateForgeSettings(
     $user: String
     $password: String
 ) {
-    updateForgeSettings(
-        siteKey: $siteKey
-        settings: {url: $url, id: $id, user: $user, password: $password}
-    ) {
-        siteKey
-        url
-        id
-        user
-        passwordSet
+    forge {
+        updateSettings(
+            siteKey: $siteKey
+            settings: {url: $url, id: $id, user: $user, password: $password}
+        ) {
+            siteKey
+            url
+            id
+            user
+            passwordSet
+        }
     }
 }

--- a/tests/cypress/fixtures/graphql/query/getCategorySettings.graphql
+++ b/tests/cypress/fixtures/graphql/query/getCategorySettings.graphql
@@ -1,19 +1,21 @@
 query ForgeCategorySettings($siteKey: String!) {
-    forgeCategorySettings(siteKey: $siteKey) {
-        siteKey
-        rootCategoryUuid
-        rootCategoryPath
-        rootCategoryDisplayName
-        siteLanguages
-        categories {
-            uuid
-            name
-            displayName
-            titles {
-                language
-                title
+    forge {
+        categorySettings(siteKey: $siteKey) {
+            siteKey
+            rootCategoryUuid
+            rootCategoryPath
+            rootCategoryDisplayName
+            siteLanguages
+            categories {
+                uuid
+                name
+                displayName
+                titles {
+                    language
+                    title
+                }
+                usages
             }
-            usages
         }
     }
 }

--- a/tests/cypress/fixtures/graphql/query/getForgeSettings.graphql
+++ b/tests/cypress/fixtures/graphql/query/getForgeSettings.graphql
@@ -1,9 +1,11 @@
 query ForgeSettings($siteKey: String!) {
-    forgeSettings(siteKey: $siteKey) {
-        siteKey
-        url
-        id
-        user
-        passwordSet
+    forge {
+        settings(siteKey: $siteKey) {
+            siteKey
+            url
+            id
+            user
+            passwordSet
+        }
     }
 }

--- a/tests/cypress/fixtures/graphql/query/getManageRolesSettings.graphql
+++ b/tests/cypress/fixtures/graphql/query/getManageRolesSettings.graphql
@@ -1,12 +1,14 @@
 query ManageRolesSettings($siteKey: String!) {
-    manageRolesSettings(siteKey: $siteKey) {
-        siteKey
-        roles {
-            role
-            members {
-                name
-                type
-                displayName
+    forge {
+        manageRolesSettings(siteKey: $siteKey) {
+            siteKey
+            roles {
+                role
+                members {
+                    name
+                    type
+                    displayName
+                }
             }
         }
     }

--- a/tests/cypress/fixtures/graphql/query/searchForgePrincipals.graphql
+++ b/tests/cypress/fixtures/graphql/query/searchForgePrincipals.graphql
@@ -1,7 +1,9 @@
 query SearchForgePrincipals($siteKey: String!, $searchTerm: String!, $type: ForgePrincipalType!) {
-    searchForgePrincipals(siteKey: $siteKey, searchTerm: $searchTerm, type: $type) {
-        name
-        type
-        displayName
+    forge {
+        searchPrincipals(siteKey: $siteKey, searchTerm: $searchTerm, type: $type) {
+            name
+            type
+            displayName
+        }
     }
 }


### PR DESCRIPTION
## Why

The store's GraphQL operations each extended the root `Query`/`Mutation` with **flat top-level fields**, polluting the global schema with 11 store-specific fields sitting next to `jcr`, `admin`, etc.:

- Query: `forgeSettings`, `forgeCategorySettings`, `manageRolesSettings`, `searchForgePrincipals`
- Mutation: `updateForgeSettings`, `setRootCategory`, `addForgeCategory`, `updateForgeCategoryTitles`, `deleteForgeCategory`, `grantSiteRole`, `revokeSiteRole`

## What

Group everything under a single `forge` namespace on each root type:

```graphql
query    { forge { settings, categorySettings, manageRolesSettings, searchPrincipals } }
mutation { forge { updateSettings, setRootCategory, addCategory,
                   updateCategoryTitles, deleteCategory, grantRole, revokeRole } }
```

- New `ForgeQuery`/`ForgeMutation` container types hold the `@GraphQLField` methods; `ForgeQueryExtension`/`ForgeMutationExtension` add the single `forge` field to `Query`/`Mutation` (auto-registered by `BundleScanner` via `@GraphQLTypeExtension`).
- The six former extension classes keep **all logic + authorization** (`validateSiteKey`, `assertManagedBySite`, the role allowlist, …) and become plain static logic-holders the containers delegate to — **no behavior change**.
- Redundant `forge`-prefixes dropped from the nested field names now that the namespace carries them.

### Deliberately *not* changed
The category/role mutations overlap with core's generic `jcr`/ACL mutations, but they are **kept** (only namespaced) — their site-scoped guards are the SECURITY-571 value-add; replacing them with generic JCR writes would re-widen the attack surface.

### Out of scope
`store-template` is unaffected — its branding reader uses the `ForgeSettingsService` OSGi bridge, not GraphQL.

## Test plan

- [x] Java compiles; all unit tests pass; admin webpack bundle builds
- [x] Admin client (`.gql.js` + result-read paths) moved to the nested shape
- [x] Cypress fixtures (12) + specs (6) updated; no stale flat paths remain
- [x] **Full E2E suite: 121/121, all 20 specs passed** — live-Jahia proof that the `forge` namespace registers in DXGraphQLProvider and every operation resolves under it