### PR TITLE
fix(settings): per-site ManagedServiceFactory so store config survives Jahia restart

### DIFF
--- a/src/main/java/org/jahia/modules/forge/settings/ForgeSettingsServiceImpl.java
+++ b/src/main/java/org/jahia/modules/forge/settings/ForgeSettingsServiceImpl.java
@@ -1,33 +1,65 @@
 package org.jahia.modules.forge.settings;
 
 import org.apache.commons.lang.StringUtils;
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationAdmin;
-import org.osgi.service.component.annotations.Activate;
+import org.osgi.framework.Constants;
+import org.osgi.service.cm.ConfigurationException;
+import org.osgi.service.cm.ManagedServiceFactory;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Base64;
 import java.util.Dictionary;
-import java.util.Hashtable;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.regex.Pattern;
 
 /**
- * {@link ForgeSettingsService} backed by per-site OSGi factory configuration
- * (PID factory {@value #FACTORY_PID}). One configuration instance per site, identified by a
- * stored {@code siteKey} property. The password is stored base64-obfuscated (same reversible
- * obfuscation as the previous JCR storage — an accepted risk; a follow-up should move it to a
- * real secret store).
+ * {@link ForgeSettingsService} implemented as an OSGi {@link ManagedServiceFactory} keyed by site:
+ * each site's settings are a <em>factory configuration</em> of PID {@value #FACTORY_PID}, carried by
+ * a file {@code <KARAF_ETC>/org.jahia.modules.forge.forgeSettings-<siteKey>.cfg}.
+ *
+ * <p>Felix FileInstall turns every such {@code .cfg} into a configuration instance and the OSGi
+ * configuration runtime delivers it to {@link #updated(String, Dictionary)}, keyed by its
+ * {@code siteKey} property; {@link #get(String)} then serves the live in-memory map. Because the
+ * configuration lives in a file, it survives restarts and redeploys unconditionally and can be
+ * hand-edited in {@code karaf/etc} (FileInstall re-delivers the change). This replaces an earlier
+ * design that created the per-site configuration programmatically through {@code ConfigurationAdmin}:
+ * once a default config file shipped for the same factory PID, those API-created instances were
+ * dropped on restart and the store configuration was lost.
+ *
+ * <p>The admin UI saves by writing that same file ({@link #save}/{@link #delete}), so there is one
+ * configuration representation consumed one way. The password is stored base64-obfuscated (same
+ * reversible obfuscation as before — an accepted risk; a follow-up should use a real secret store).
  */
-@Component(service = ForgeSettingsService.class, immediate = true)
-public class ForgeSettingsServiceImpl implements ForgeSettingsService {
+@Component(
+        service = {ForgeSettingsService.class, ManagedServiceFactory.class},
+        property = Constants.SERVICE_PID + "=" + ForgeSettingsServiceImpl.FACTORY_PID,
+        immediate = true)
+public class ForgeSettingsServiceImpl implements ForgeSettingsService, ManagedServiceFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ForgeSettingsServiceImpl.class);
 
     static final String FACTORY_PID = "org.jahia.modules.forge.forgeSettings";
+
+    /** Karaf system properties locating {@code <JAHIA_HOME>/digital-factory-data/karaf/etc}. */
+    private static final String KARAF_ETC = "karaf.etc";
+    private static final String KARAF_HOME = "karaf.home";
+
+    /**
+     * A site key is interpolated into the config file name, so it must be a safe single path
+     * segment — alphanumeric start, then alphanumerics, dot, underscore or hyphen. This rejects any
+     * separator or {@code ..} traversal before it can reach the file system.
+     */
+    private static final Pattern SAFE_SITE_KEY = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._-]*");
 
     private static final String P_SITE_KEY = "siteKey";
     private static final String P_URL = "url";
@@ -45,113 +77,218 @@ public class ForgeSettingsServiceImpl implements ForgeSettingsService {
     private static final String P_YOUTUBE_URL = "youtubeUrl";
     private static final String P_ROOT_CATEGORY = "rootCategoryUuid";
 
-    private final ConfigurationAdmin configAdmin;
+    private static final String FILE_HEADER =
+            "Jahia private app store - per-site settings. Managed by the store administration UI; "
+            + "safe to hand-edit. 'siteKey' selects the site these settings apply to.";
 
-    @Activate
-    public ForgeSettingsServiceImpl(@Reference ConfigurationAdmin configAdmin) {
-        this.configAdmin = configAdmin;
+    /** Live per-site settings, populated from configuration instances delivered to {@link #updated}. */
+    private final ConcurrentHashMap<String, ForgeSettings> bySite = new ConcurrentHashMap<>();
+    /** Configuration instance PID -> the site key it carries, so {@link #deleted} can evict by site. */
+    private final ConcurrentHashMap<String, String> pidToSite = new ConcurrentHashMap<>();
+
+    // --- ManagedServiceFactory: receive per-site factory configuration instances ---------------
+
+    @Override
+    public String getName() {
+        return "Private App Store per-site settings";
     }
 
     @Override
-    public ForgeSettings get(String siteKey) {
-        try {
-            final Configuration cfg = findConfig(siteKey);
-            if (cfg == null || cfg.getProperties() == null) {
-                return ForgeSettings.empty();
-            }
-            return toSettings(cfg.getProperties());
-        } catch (IOException e) {
-            LOGGER.error("Unable to read forge settings for site {}", siteKey, e);
-            return ForgeSettings.empty();
+    public void updated(String pid, Dictionary<String, ?> properties) throws ConfigurationException {
+        final String siteKey = str(properties::get, P_SITE_KEY);
+        if (StringUtils.isBlank(siteKey)) {
+            // The shipped template ships with an empty siteKey; ignore it until an admin sets one.
+            LOGGER.debug("Ignoring forge settings configuration {} with no siteKey", pid);
+            return;
         }
+        final String previousSite = pidToSite.put(pid, siteKey);
+        if (previousSite != null && !previousSite.equals(siteKey)) {
+            bySite.remove(previousSite);
+        }
+        bySite.put(siteKey, toSettings(key -> str(properties::get, key)));
+        LOGGER.debug("Loaded forge settings for site '{}' (configuration {})", siteKey, pid);
+    }
+
+    @Override
+    public void deleted(String pid) {
+        final String siteKey = pidToSite.remove(pid);
+        if (siteKey != null) {
+            bySite.remove(siteKey);
+            LOGGER.debug("Removed forge settings for site '{}' (configuration {})", siteKey, pid);
+        }
+    }
+
+    // --- ForgeSettingsService ------------------------------------------------------------------
+
+    @Override
+    public ForgeSettings get(String siteKey) {
+        final ForgeSettings settings = bySite.get(siteKey);
+        return (settings != null) ? settings : ForgeSettings.empty();
     }
 
     @Override
     public void save(String siteKey, ForgeSettings settings) {
+        final File file = configFile(siteKey);
+        if (file == null) {
+            throw new ForgeSettingsConfigException(
+                    "Refusing to persist forge settings: unusable site key '" + siteKey + "' or no karaf/etc", null);
+        }
+        // A blank password leaves the previously stored (base64) value untouched, so carry it over.
+        final String keptPassword = loadExisting(file).getProperty(P_PASSWORD);
+
+        final Properties props = new Properties();
+        props.setProperty(P_SITE_KEY, siteKey);
+        putOrSkip(props, P_URL, settings.getUrl());
+        putOrSkip(props, P_ID, settings.getId());
+        putOrSkip(props, P_USER, settings.getUser());
+        putOrSkip(props, P_LOGO_PATH, settings.getLogoPath());
+        putOrSkip(props, P_COPYRIGHT, settings.getCopyright());
+        putOrSkip(props, P_PRIVACY_URL, settings.getPrivacyUrl());
+        putOrSkip(props, P_TERMS_URL, settings.getTermsUrl());
+        putOrSkip(props, P_COOKIES_URL, settings.getCookiesUrl());
+        putOrSkip(props, P_FACEBOOK_URL, settings.getFacebookUrl());
+        putOrSkip(props, P_LINKEDIN_URL, settings.getLinkedinUrl());
+        putOrSkip(props, P_TWITTER_URL, settings.getTwitterUrl());
+        putOrSkip(props, P_YOUTUBE_URL, settings.getYoutubeUrl());
+        putOrSkip(props, P_ROOT_CATEGORY, settings.getRootCategoryUuid());
+        if (StringUtils.isNotBlank(settings.getPassword())) {
+            props.setProperty(P_PASSWORD, Base64.getEncoder()
+                    .encodeToString(settings.getPassword().getBytes(StandardCharsets.UTF_8)));
+        } else if (StringUtils.isNotBlank(keptPassword)) {
+            props.setProperty(P_PASSWORD, keptPassword);
+        }
+
         try {
-            Configuration cfg = findConfig(siteKey);
-            if (cfg == null) {
-                // bound to no specific bundle ("?") so it survives module reinstall
-                cfg = configAdmin.createFactoryConfiguration(FACTORY_PID, "?");
-            }
-            Dictionary<String, Object> d = cfg.getProperties();
-            if (d == null) {
-                d = new Hashtable<>();
-            }
-            d.put(P_SITE_KEY, siteKey);
-            putOrRemove(d, P_URL, settings.getUrl());
-            putOrRemove(d, P_ID, settings.getId());
-            putOrRemove(d, P_USER, settings.getUser());
-            putOrRemove(d, P_LOGO_PATH, settings.getLogoPath());
-            putOrRemove(d, P_COPYRIGHT, settings.getCopyright());
-            putOrRemove(d, P_PRIVACY_URL, settings.getPrivacyUrl());
-            putOrRemove(d, P_TERMS_URL, settings.getTermsUrl());
-            putOrRemove(d, P_COOKIES_URL, settings.getCookiesUrl());
-            putOrRemove(d, P_FACEBOOK_URL, settings.getFacebookUrl());
-            putOrRemove(d, P_LINKEDIN_URL, settings.getLinkedinUrl());
-            putOrRemove(d, P_TWITTER_URL, settings.getTwitterUrl());
-            putOrRemove(d, P_YOUTUBE_URL, settings.getYoutubeUrl());
-            putOrRemove(d, P_ROOT_CATEGORY, settings.getRootCategoryUuid());
-            // Blank password leaves the previously stored (base64) value untouched.
-            if (StringUtils.isNotBlank(settings.getPassword())) {
-                d.put(P_PASSWORD, Base64.getEncoder()
-                        .encodeToString(settings.getPassword().getBytes(StandardCharsets.UTF_8)));
-            }
-            cfg.update(d);
+            writeAtomic(file, props);
         } catch (IOException e) {
-            // Surface as RepositoryException so the GraphQL mutation reports a structured error.
+            // Surface so the GraphQL mutation reports a structured error rather than failing silently.
             throw new ForgeSettingsConfigException("Unable to persist forge settings for site " + siteKey, e);
         }
+        // Reflect the change immediately; FileInstall will re-deliver the same data via updated().
+        bySite.put(siteKey, toSettings(props::getProperty));
     }
 
     @Override
     public void delete(String siteKey) {
+        final File file = configFile(siteKey);
+        bySite.remove(siteKey);
+        if (file == null || !file.isFile()) {
+            return;
+        }
         try {
-            final Configuration cfg = findConfig(siteKey);
-            if (cfg != null) {
-                cfg.delete();
-            }
+            // FileInstall observes the removal and calls deleted(pid); the eviction above is immediate.
+            Files.delete(file.toPath());
         } catch (IOException e) {
             LOGGER.error("Unable to delete forge settings for site {}", siteKey, e);
         }
     }
 
-    /** Find the single configuration instance for a site, or null when none exists yet. */
-    private Configuration findConfig(String siteKey) throws IOException {
-        try {
-            final String filter = "(&(service.factoryPid=" + FACTORY_PID + ")(" + P_SITE_KEY + "="
-                    + escape(siteKey) + "))";
-            final Configuration[] cfgs = configAdmin.listConfigurations(filter);
-            return (cfgs != null && cfgs.length > 0) ? cfgs[0] : null;
-        } catch (org.osgi.framework.InvalidSyntaxException e) {
-            LOGGER.error("Invalid configuration filter for site {}", siteKey, e);
+    // --- file helpers --------------------------------------------------------------------------
+
+    /**
+     * The {@code .cfg} file for a site, or {@code null} when the site key is unsafe or no
+     * {@code karaf/etc} can be located. Package-private for tests.
+     */
+    File configFile(String siteKey) {
+        if (!isSafeSiteKey(siteKey)) {
             return null;
+        }
+        final File etc = etcDir();
+        return (etc != null) ? new File(etc, configFileName(siteKey)) : null;
+    }
+
+    /** The config file name for a site key. Package-private and pure, for tests. */
+    static String configFileName(String siteKey) {
+        return FACTORY_PID + "-" + siteKey + ".cfg";
+    }
+
+    /** Whether a site key is a safe single file-name segment. Package-private and pure, for tests. */
+    static boolean isSafeSiteKey(String siteKey) {
+        return StringUtils.isNotBlank(siteKey) && SAFE_SITE_KEY.matcher(siteKey).matches();
+    }
+
+    private static File etcDir() {
+        File dir = null;
+        final String etc = System.getProperty(KARAF_ETC);
+        if (StringUtils.isNotBlank(etc)) {
+            dir = new File(etc);
+        } else {
+            final String home = System.getProperty(KARAF_HOME);
+            if (StringUtils.isNotBlank(home)) {
+                dir = new File(home, "etc");
+            }
+        }
+        if (dir == null || !dir.isDirectory()) {
+            LOGGER.error("Cannot locate karaf/etc (system properties '{}'/'{}'); forge settings cannot be saved",
+                    KARAF_ETC, KARAF_HOME);
+            return null;
+        }
+        return dir;
+    }
+
+    private static Properties loadExisting(File file) {
+        final Properties props = new Properties();
+        if (file.isFile()) {
+            try {
+                try (java.io.InputStream in = Files.newInputStream(file.toPath())) {
+                    props.load(in);
+                }
+            } catch (IOException e) {
+                LOGGER.warn("Unable to read existing forge settings file {}; treating as empty", file, e);
+            }
+        }
+        return props;
+    }
+
+    /** Write properties to a temp file in the same directory, then move it into place atomically. */
+    private static void writeAtomic(File file, Properties props) throws IOException {
+        final Path target = file.toPath();
+        final Path tmp = Files.createTempFile(target.getParent(), file.getName(), ".tmp");
+        try {
+            try (OutputStream out = Files.newOutputStream(tmp)) {
+                props.store(out, FILE_HEADER);
+            }
+            try {
+                Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (IOException atomicUnsupported) {
+                Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } finally {
+            Files.deleteIfExists(tmp);
         }
     }
 
-    private ForgeSettings toSettings(Dictionary<String, Object> d) {
-        final String password = decodePassword(str(d, P_PASSWORD));
+    // --- mapping -------------------------------------------------------------------------------
+
+    /** Build settings from any string-keyed source (a config {@link Dictionary} or a {@link Properties}). */
+    private static ForgeSettings toSettings(Function<String, String> get) {
         return ForgeSettings.builder()
-                .url(str(d, P_URL))
-                .id(str(d, P_ID))
-                .user(str(d, P_USER))
-                .password(password)
-                .logoPath(str(d, P_LOGO_PATH))
-                .copyright(str(d, P_COPYRIGHT))
-                .privacyUrl(str(d, P_PRIVACY_URL))
-                .termsUrl(str(d, P_TERMS_URL))
-                .cookiesUrl(str(d, P_COOKIES_URL))
-                .facebookUrl(str(d, P_FACEBOOK_URL))
-                .linkedinUrl(str(d, P_LINKEDIN_URL))
-                .twitterUrl(str(d, P_TWITTER_URL))
-                .youtubeUrl(str(d, P_YOUTUBE_URL))
-                .rootCategoryUuid(str(d, P_ROOT_CATEGORY))
+                .url(blankToNull(get.apply(P_URL)))
+                .id(blankToNull(get.apply(P_ID)))
+                .user(blankToNull(get.apply(P_USER)))
+                .password(decodePassword(get.apply(P_PASSWORD)))
+                .logoPath(blankToNull(get.apply(P_LOGO_PATH)))
+                .copyright(blankToNull(get.apply(P_COPYRIGHT)))
+                .privacyUrl(blankToNull(get.apply(P_PRIVACY_URL)))
+                .termsUrl(blankToNull(get.apply(P_TERMS_URL)))
+                .cookiesUrl(blankToNull(get.apply(P_COOKIES_URL)))
+                .facebookUrl(blankToNull(get.apply(P_FACEBOOK_URL)))
+                .linkedinUrl(blankToNull(get.apply(P_LINKEDIN_URL)))
+                .twitterUrl(blankToNull(get.apply(P_TWITTER_URL)))
+                .youtubeUrl(blankToNull(get.apply(P_YOUTUBE_URL)))
+                .rootCategoryUuid(blankToNull(get.apply(P_ROOT_CATEGORY)))
                 .build();
     }
 
-    private static String str(Dictionary<String, Object> d, String key) {
-        final Object v = d.get(key);
-        return (v != null) ? v.toString() : null;
+    /** Read a value from a config dictionary as a string (null when absent). */
+    private static String str(Function<String, Object> get, String key) {
+        final Object value = get.apply(key);
+        return (value != null) ? value.toString() : null;
+    }
+
+    /** Normalise blank (e.g. a {@code url=} line in the shipped template) to null. */
+    private static String blankToNull(String value) {
+        return StringUtils.isNotBlank(value) ? value : null;
     }
 
     /**
@@ -171,18 +308,10 @@ public class ForgeSettingsServiceImpl implements ForgeSettingsService {
         }
     }
 
-    private static void putOrRemove(Dictionary<String, Object> d, String key, String value) {
+    private static void putOrSkip(Properties props, String key, String value) {
         if (StringUtils.isNotBlank(value)) {
-            d.put(key, value);
-        } else {
-            d.remove(key);
+            props.setProperty(key, value);
         }
-    }
-
-    /** Escape the value half of an LDAP/OSGi filter assertion. */
-    static String escape(String value) {
-        return value.replace("\\", "\\5c").replace("*", "\\2a")
-                .replace("(", "\\28").replace(")", "\\29");
     }
 
     /** Lets a config I/O failure surface through the JCR-exception-based mutation error path. */

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.forge.forgeSettings-default.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.forge.forgeSettings-default.cfg
@@ -1,16 +1,19 @@
 # default configuration - won't be overridden
 #
-# Private App Store - per-site settings (OSGi factory configuration
+# Private App Store - per-site settings (a factory configuration of PID
 # "org.jahia.modules.forge.forgeSettings"; one configuration instance per site).
 #
-# On install this file is deployed to <JAHIA_HOME>/digital-factory-data/karaf/etc/ and is
-# SAFE TO EDIT there: the "won't be overridden" marker on the first line stops Jahia from
-# overwriting your changes the next time the module is (re)deployed. The same settings are
-# also editable in-product through the store administration UI.
+# WHICH SITE THESE SETTINGS APPLY TO: the "siteKey" property below - NOT the file name. As shipped
+# "siteKey" is empty, so this template is inert until you set it. To configure your store, set
+# "siteKey" to your site (the <siteKey> in /sites/<siteKey>). To run several stores, copy this file
+# inside <JAHIA_HOME>/digital-factory-data/karaf/etc/ to
+#     org.jahia.modules.forge.forgeSettings-<siteKey>.cfg
+# (one copy per site) and set "siteKey" in each.
 #
-# IMPORTANT: these settings only apply to the site whose key matches "siteKey" below, so set
-# it to your store's site. To run several stores, copy this file per site as
-# "org.jahia.modules.forge.forgeSettings-<siteKey>.cfg" and set "siteKey" in each.
+# The store reads these settings live, so edits take effect on the next read (no restart needed) and
+# survive restarts and module redeploys - the "won't be overridden" marker on the first line keeps
+# the deployed copy from being reset on redeploy. The same settings are editable in the store
+# administration UI, which writes this very file.
 
 # Site key of the store these settings apply to (the <siteKey> in /sites/<siteKey>).
 siteKey=

--- a/src/test/java/org/jahia/modules/forge/settings/ForgeSettingsServiceImplTest.java
+++ b/src/test/java/org/jahia/modules/forge/settings/ForgeSettingsServiceImplTest.java
@@ -2,42 +2,129 @@ package org.jahia.modules.forge.settings;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.osgi.service.cm.ConfigurationException;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Dictionary;
+import java.util.Hashtable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Unit tests for {@link ForgeSettingsServiceImpl#escape(String)} — the LDAP/OSGi filter-assertion
- * escaper that keeps an attacker-influenced siteKey from injecting into the configuration filter
- * {@code (&(service.factoryPid=...)(siteKey=<value>))}. Pure logic, no OSGi runtime required.
+ * Unit tests for {@link ForgeSettingsServiceImpl}. The {@link org.osgi.service.cm.ManagedServiceFactory}
+ * dispatch ({@code updated}/{@code get}/{@code deleted}) is exercised directly with a configuration
+ * {@link Dictionary} — no OSGi runtime needed. The pure helpers (site-key safety, file name and the
+ * password decoder) are covered too; the file write/read round-trip against a live Jahia is covered
+ * by the Cypress E2E.
  */
 class ForgeSettingsServiceImplTest {
 
-    @Test
-    @DisplayName("escape leaves a plain value untouched")
-    void escape_plain() {
-        assertThat(ForgeSettingsServiceImpl.escape("my-store")).isEqualTo("my-store");
+    private static Dictionary<String, Object> config(String siteKey) {
+        final Dictionary<String, Object> d = new Hashtable<>();
+        if (siteKey != null) {
+            d.put("siteKey", siteKey);
+        }
+        return d;
     }
 
     @Test
-    @DisplayName("escape encodes each RFC 4515 special character")
-    void escape_specialChars() {
-        assertThat(ForgeSettingsServiceImpl.escape("*")).isEqualTo("\\2a");
-        assertThat(ForgeSettingsServiceImpl.escape("(")).isEqualTo("\\28");
-        assertThat(ForgeSettingsServiceImpl.escape(")")).isEqualTo("\\29");
-        assertThat(ForgeSettingsServiceImpl.escape("\\")).isEqualTo("\\5c");
+    @DisplayName("updated then get returns the configuration keyed by siteKey; unknown site is empty")
+    void updated_get_bySiteKey() throws ConfigurationException {
+        final ForgeSettingsServiceImpl service = new ForgeSettingsServiceImpl();
+        final Dictionary<String, Object> d = config("storeA");
+        d.put("url", "https://nexus.example/releases");
+        d.put("copyright", "ACME");
+
+        service.updated("pid-a", d);
+
+        assertThat(service.get("storeA").getUrl()).isEqualTo("https://nexus.example/releases");
+        assertThat(service.get("storeA").getCopyright()).isEqualTo("ACME");
+        // A site with no configuration instance reads as empty, never null.
+        assertThat(service.get("unknown").getUrl()).isNull();
     }
 
     @Test
-    @DisplayName("escape neutralises a filter-injection attempt and escapes backslash FIRST")
-    void escape_injectionAttempt() {
-        // A crafted wildcard/paren payload must not survive as filter syntax.
-        assertThat(ForgeSettingsServiceImpl.escape("*)(uid=*"))
-                .isEqualTo("\\2a\\29\\28uid=\\2a");
-        // Backslash is escaped before the others so its own escape is not re-escaped.
-        assertThat(ForgeSettingsServiceImpl.escape("\\*")).isEqualTo("\\5c\\2a");
+    @DisplayName("updated decodes the base64 password")
+    void updated_decodesPassword() throws ConfigurationException {
+        final ForgeSettingsServiceImpl service = new ForgeSettingsServiceImpl();
+        final Dictionary<String, Object> d = config("storeA");
+        d.put("password", Base64.getEncoder().encodeToString("s3cr3t!".getBytes(StandardCharsets.UTF_8)));
+
+        service.updated("pid-a", d);
+
+        assertThat(service.get("storeA").getPassword()).isEqualTo("s3cr3t!");
+    }
+
+    @Test
+    @DisplayName("a configuration with no siteKey (the shipped template) is ignored")
+    void updated_blankSiteKeyIgnored() throws ConfigurationException {
+        final ForgeSettingsServiceImpl service = new ForgeSettingsServiceImpl();
+
+        service.updated("pid-template", config(null));
+        service.updated("pid-empty", config(""));
+
+        // Nothing was registered, so any lookup is empty (and no NPE on the missing key).
+        assertThat(service.get("").getUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("deleted evicts the site that the configuration PID carried")
+    void deleted_evictsBySite() throws ConfigurationException {
+        final ForgeSettingsServiceImpl service = new ForgeSettingsServiceImpl();
+        final Dictionary<String, Object> d = config("storeA");
+        d.put("url", "https://nexus.example/releases");
+        service.updated("pid-a", d);
+
+        service.deleted("pid-a");
+
+        assertThat(service.get("storeA").getUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("re-keying a configuration to a new siteKey drops the old site")
+    void updated_rekeyDropsOldSite() throws ConfigurationException {
+        final ForgeSettingsServiceImpl service = new ForgeSettingsServiceImpl();
+        final Dictionary<String, Object> first = config("storeA");
+        first.put("url", "https://a.example");
+        service.updated("pid-x", first);
+
+        final Dictionary<String, Object> second = config("storeB");
+        second.put("url", "https://b.example");
+        service.updated("pid-x", second);
+
+        assertThat(service.get("storeA").getUrl()).isNull();
+        assertThat(service.get("storeB").getUrl()).isEqualTo("https://b.example");
+    }
+
+    @Test
+    @DisplayName("isSafeSiteKey accepts a plain site key")
+    void isSafeSiteKey_plain() {
+        assertThat(ForgeSettingsServiceImpl.isSafeSiteKey("my-store")).isTrue();
+        assertThat(ForgeSettingsServiceImpl.isSafeSiteKey("store1")).isTrue();
+        assertThat(ForgeSettingsServiceImpl.isSafeSiteKey("a.b_c-d")).isTrue();
+    }
+
+    @Test
+    @DisplayName("isSafeSiteKey rejects blank, null, separators and traversal")
+    void isSafeSiteKey_unsafe() {
+        assertThat(ForgeSettingsServiceImpl.isSafeSiteKey(null)).isFalse();
+        assertThat(ForgeSettingsServiceImpl.isSafeSiteKey("")).isFalse();
+        assertThat(ForgeSettingsServiceImpl.isSafeSiteKey("   ")).isFalse();
+        // Anything that could escape the etc directory must be refused before reaching the file name.
+        assertThat(ForgeSettingsServiceImpl.isSafeSiteKey("..")).isFalse();
+        assertThat(ForgeSettingsServiceImpl.isSafeSiteKey("../evil")).isFalse();
+        assertThat(ForgeSettingsServiceImpl.isSafeSiteKey("a/b")).isFalse();
+        assertThat(ForgeSettingsServiceImpl.isSafeSiteKey("a\\b")).isFalse();
+        assertThat(ForgeSettingsServiceImpl.isSafeSiteKey(".hidden")).isFalse();
+        assertThat(ForgeSettingsServiceImpl.isSafeSiteKey("with space")).isFalse();
+    }
+
+    @Test
+    @DisplayName("configFileName puts the site key in the factory-PID file name")
+    void configFileName_format() {
+        assertThat(ForgeSettingsServiceImpl.configFileName("mystore"))
+                .isEqualTo("org.jahia.modules.forge.forgeSettings-mystore.cfg");
     }
 
     @Test


### PR DESCRIPTION
## Problem

Store configuration was **lost on every Jahia restart**.

The per-site settings were created as a programmatic `ConfigurationAdmin` factory configuration and read back by querying `ConfigurationAdmin` directly. Once a default config file shipped for the same factory PID (#f909b50), Felix FileInstall / the Jahia module extender took ownership of that PID at boot and the API-created sibling instances were dropped on restart.

## Fix

Model each site's settings as an OSGi **factory configuration** of PID `org.jahia.modules.forge.forgeSettings`, carried by a file `<karaf.etc>/org.jahia.modules.forge.forgeSettings-<siteKey>.cfg`.

`ForgeSettingsServiceImpl` now registers as a **`ManagedServiceFactory` keyed by the `siteKey` property**:
- Felix FileInstall turns each `.cfg` into a configuration instance; the runtime delivers it to `updated(pid, props)`, populating a live per-site map that `get()` serves.
- `save()` / `delete()` write / remove that same file atomically — the admin UI writes the very file an admin could hand-edit.
- One configuration representation, consumed the OSGi way; **file-backed, so it survives restarts and redeploys unconditionally**. No more programmatic `createFactoryConfiguration`.
- `siteKey` is validated as a safe single path segment before reaching the file system; base64/plaintext `decodePassword` tolerance kept.

The shipped `-default.cfg` is a copy-per-site template (`siteKey` selects the site).

## Tests

- 98 JUnit (was 91). New coverage of the factory dispatch — `updated`/`get`/`deleted`, blank-`siteKey` ignore, re-key — plus site-key safety, file-name and password helpers.
- DS descriptor verified: registered under both `ForgeSettingsService` and `ManagedServiceFactory` with `service.pid=org.jahia.modules.forge.forgeSettings`.
- **Restart-survival confirmed by the maintainer** in a live instance.

## Note

Per-site settings created by the previous API-based code are **not auto-migrated** — re-save once in the admin UI (or drop the values straight into the `karaf/etc` `.cfg`).