### PR TITLE
docs: correct forge-settings storage (OSGi ManagedServiceFactory, not JCR)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,13 +75,21 @@ authenticated users are denied (`GqlAccessDeniedException`). This shapes the API
 - `jnt:post` carries `jcr:title` + `content`.
 - No same-name siblings — `addNode` with an existing name throws
   `ItemExistsException` (used for atomic per-user dedup).
-- **`jmix:forgeSettings`** (mixin on the site node) holds the forge connection
-  (`forgeSettingsUrl`/`Id`/`User`/`Password` base64 + `rootCategory`) AND the site
-  branding read by the jahia-store-template chrome: `forgeSettingsLogo` (weakreference to
-  a media image) plus footer strings `forgeSettingsCopyright` / `*PrivacyUrl` /
-  `*TermsUrl` / `*CookiesUrl` / `*FacebookUrl` / `*LinkedinUrl` / `*TwitterUrl` /
-  `*YoutubeUrl`. Exposed/edited via the `forge { settings }` query + `forge { updateSettings }`
-  mutation (shared `ForgeSettingsReader`; `GqlForgeSettings` uses a builder). All store GraphQL
+- **Forge settings are NOT stored in JCR.** The `jmix:forgeSettings` mixin is dormant (like
+  `jnt:review*` above). Per-site settings — the forge connection (`url`/`id`/`user`/`password`
+  base64 + `rootCategoryUuid`) and the storefront branding read by the jahia-store-template chrome
+  (`logoPath` plus footer strings `copyright` / `privacyUrl` / `termsUrl` / `cookiesUrl` /
+  `facebookUrl` / `linkedinUrl` / `twitterUrl` / `youtubeUrl`) — live in a per-site **OSGi factory
+  configuration** `<karaf.etc>/org.jahia.modules.forge.forgeSettings-<siteKey>.cfg`. They are served
+  by `ForgeSettingsServiceImpl`, a `ManagedServiceFactory` keyed by the `siteKey` property: Felix
+  FileInstall delivers each `.cfg` to `updated()` into a live per-site map; `save()`/`delete()`
+  write/remove that file atomically. File-backed, so settings survive restarts and redeploys (the
+  earlier programmatic `ConfigurationAdmin.createFactoryConfiguration` instances were lost on
+  restart). The logo is a plain DAM **path string**, not a JCR weakreference. Exposed/edited via the
+  `forge { settings }` query + `forge { updateSettings }` mutation (`GqlForgeSettings` uses a
+  builder); the SSR chrome reads branding in-process via
+  `server.osgi.getService("org.jahia.modules.forge.settings.ForgeSettingsService")` (the
+  permission-gated GraphQL field is unusable for anonymous storefront rendering). All store GraphQL
   operations are namespaced under a single `forge` field on the root Query/Mutation
   (`ForgeQueryExtension`/`ForgeMutationExtension` → `ForgeQuery`/`ForgeMutation` containers),
   rather than flat top-level fields.

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,7 +18,7 @@ The provisioning manifest installs Jahia plus:
 - `jahia-store` — the backend module being tested (taken from `../target/*-SNAPSHOT.jar` when present, otherwise from Nexus).
 - `jahia-store-template` — the front-end templates set, pulled from a local sibling checkout at `../../store-template/target/*-SNAPSHOT.tgz` when present, otherwise from Nexus (see `provisioning-manifest-snapshot.yml`). The on-disk folder keeps its `store-template/` name.
 
-Nexus is reachable from inside the network at `http://nexus:8081` (Jahia / Cypress) and from the host at `http://localhost:8081`. The forge module's per-site `jnt:forgeSettings` should point at the internal URL when configured by a test, using the credentials exposed via the `NEXUS_USERNAME` / `NEXUS_PASSWORD` environment variables.
+Nexus is reachable from inside the network at `http://nexus:8081` (Jahia / Cypress) and from the host at `http://localhost:8081`. A test configures the forge module's per-site settings (Nexus URL + credentials) through the store admin GraphQL (`forge { updateSettings }`) or the `ForgeSettingsService` — they are stored as a per-site OSGi factory config (`karaf/etc/org.jahia.modules.forge.forgeSettings-<siteKey>.cfg`), not JCR properties. Point the URL at the internal `http://nexus:8081`, using the `NEXUS_USERNAME` / `NEXUS_PASSWORD` credentials.
 
 On first boot Nexus auto-creates two hosted Maven repositories (`maven-releases`, `maven-snapshots`) which the forge module can use without further setup. If you need additional repos for a specific test scenario, create them via the Nexus REST API in a `before()` hook.
 


### PR DESCRIPTION
## Why

A doc audit of README/AGENTS/CLAUDE across both repos found two stale spots in **privateappstore** — both describing forge settings as JCR (`jmix:forgeSettings` / `jnt:forgeSettings` on the site node). That storage was replaced (JCR mixin → OSGi config → file-backed `ManagedServiceFactory`, PR #48). Everything else in both repos' docs is accurate.

## What

- **`AGENTS.md`** (JCR content-model section): the forge-settings bullet now states settings are **not** in JCR — they live in a per-site OSGi factory config `<karaf.etc>/org.jahia.modules.forge.forgeSettings-<siteKey>.cfg`, served by `ForgeSettingsServiceImpl` (a `ManagedServiceFactory` keyed by `siteKey`, file-backed → survives restart). Logo is a DAM path string; the SSR chrome reads branding via the in-process `ForgeSettingsService` OSGi bridge. The `jmix:forgeSettings` mixin is noted as dormant. The GraphQL `forge { … }` namespace note (already accurate) is preserved.
- **`tests/README.md`**: replaced the `jnt:forgeSettings` configuration instruction with the current path — configure via `forge { updateSettings }` / `ForgeSettingsService`, stored as the per-site `.cfg`.

Docs-only; no code changes.

## Audit result (for the record)

- privateappstore: `README.md` ✅, `CLAUDE.md` ✅, `AGENTS.md`/`tests/README.md` fixed here.
- store-template: `README.md` / `AGENTS.md` / `CLAUDE.md` / `docs/*` all accurate (the OSGi-bridge branding, CKEditor-5 remote, superseded migration banner, and CSP/xss sanitizer descriptions match the code) — no edits needed.