### PR TITLE
fix(deps): resolve Dependabot security alerts (qs, uuid)

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -77,7 +77,9 @@
     "axios": "^1.16.0",
     "fast-uri": "^3.1.2",
     "ip-address": "^10.1.1",
+    "qs": "^6.15.2",
     "serialize-javascript": "^7.0.5",
-    "systeminformation": "^5.31.6"
+    "systeminformation": "^5.31.6",
+    "uuid": "^11.1.1"
   }
 }

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -4650,18 +4650,13 @@ punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
 
-qs@^6.4.0:
+qs@^6.15.2, qs@^6.4.0, qs@~6.14.1:
   version "6.15.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.3.tgz#76852132a58ed5c7c0ef67e4441b9bb5d6061b3b"
+  integrity sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==
   dependencies:
     es-define-property "^1.0.1"
     side-channel "^1.1.1"
-
-qs@~6.14.1:
-  version "6.14.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.2.tgz#b5634cf9d9ad9898e31fba3504e866e8efb6798c"
-  dependencies:
-    side-channel "^1.1.0"
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -5538,9 +5533,10 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-uuid@^8.3.1, uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+uuid@^11.1.1, uuid@^8.3.1, uuid@^8.3.2:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
Resolves the open npm Dependabot **security alerts** in `tests/` by anchoring patched versions with `resolutions` (durable — survives future re-resolves).

| Package | Vulnerable instance | Now | Alert |
|---------|--------------------|-----|-------|
| qs | `~6.14.1` → 6.14.2 | 6.15.3 | GHSA-q8mj-m7cp-5q26 (med, DoS in `qs.stringify`) |
| uuid | `^8.3.x` → 8.3.2 | 11.1.1 | GHSA-w5hq-g745-h8pq (med, buffer bounds in v3/v5/v6) |

### Why `resolutions` and not just a lockfile bump
Both are **transitive** deps whose patched versions lie **outside** the declared ranges (`~6.14.1` caps qs at 6.14.x; `^8.3.x` caps uuid at 8.x). A lockfile pin alone reverts to a vulnerable version on the next `yarn up` / re-resolve. An explicit `resolutions` entry is re-applied on **every** install. This matches the repo's existing convention (axios, fast-uri, ip-address, serialize-javascript, systeminformation are already pinned this way).

### uuid 8→11 safety
3-major bump, but verified safe for the test tooling: every consumer (`@cypress/request`, `mochawesome`, `jahia-reporter`, istanbul) uses the **v4 named export** (`{ v4 } = require('uuid')` / `uuid.v4()`) — no removed default-call or `uuid/vX` deep imports. Require-time smoke test passes; `yarn --frozen-lockfile` consistent.

### Not covered here
- **js-yaml** (GHSA-h67p-54hq-rp68): the `^4.x` line is **already** on patched 4.2.0. Only a transitive **3.14.2** remains, pulled by EOL coverage/CLI tooling (`@istanbuljs/load-nyc-config`, `cli-ux`, `load-yaml-file`) that needs the `safeLoad` API removed in js-yaml 4 — there is **no 3.x patch**. The DoS requires attacker-controlled YAML with merge-key aliases; this tooling only parses trusted local config, so it isn't reachable. Recommend dismissing that alert as *tolerable risk / no fix available*.