### PR TITLE
ci: fix git dubious-ownership in release workflow

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -33,6 +33,16 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.GH_SSH_PRIVATE_KEY_JAHIACI }}
 
+      # The release action forks git inside this container with a HOME that does not
+      # carry checkout@v3's temporary safe.directory entry, so a stricter git in the
+      # runner image now aborts with "detected dubious ownership" (exit 128) before
+      # Maven runs. Register the workspace as safe system-wide so every git invocation
+      # in the container (any HOME/user) is covered.
+      - name: Mark workspace safe for git (container dubious-ownership fix)
+        run: |
+          git config --system --add safe.directory '*'
+          git config --global --add safe.directory '*'
+
       - uses: jahia/jahia-modules-action/release@v2
         name: Release Module
         env:


### PR DESCRIPTION
The 5.0.1 release run failed at the `Release Module` step with `fatal: detected dubious ownership in repository` (exit 128), before Maven ran — nothing was published. `on-release.yml` is unchanged since 5_0_0 shipped, so this is an **environmental** regression (stricter git in the runner/action image).

Fix: register the workspace as a git safe.directory (system + global) in the container before the release action forks git.

After merge: re-create the `5_0_1` pre-release to retry.