### PR TITLE
fix: scope forge media mime listener by node structure (#61)

### DIFF
--- a/src/main/java/org/jahia/modules/forge/actions/ForgeMediaMimeListener.java
+++ b/src/main/java/org/jahia/modules/forge/actions/ForgeMediaMimeListener.java
@@ -38,26 +38,30 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * Server-side re-validation of the content type of uploaded module icons / screenshots
- * (SECURITY-571 #28).
+ * Server-side re-validation of the content type of files written under a forge element
+ * (module / package), guarding against a spoofed {@code jcr:mimeType} that could be served inline
+ * as script (SECURITY-571 #28, hardened for #61).
  *
- * <p>The storefront editor validates the picked file's type in the browser and then persists it via
- * a generic JCR GraphQL mutation that writes {@code jcr:mimeType} straight from the browser's
- * {@code File.type}. A module author can bypass the client allow-list by calling that mutation
- * directly and store, e.g., an SVG (which can carry scripts) under {@code jcr:mimeType=image/png}.
- * Nothing on the backend re-checked the bytes.</p>
+ * <p>A module author holds the {@code OWNER} role over their whole module subtree and writes via the
+ * generic, non-CSRF-gated {@code /modules/graphql} mutation. The storefront editor uses that path
+ * to add icons/screenshots, taking {@code jcr:mimeType} verbatim from the browser's {@code
+ * File.type}; but the same primitive lets an author store an SVG/HTML file (with a spoofed image
+ * mime) <em>anywhere</em> in the subtree, not only under {@code icon}/{@code screenshots}.</p>
  *
- * <p>This listener closes that gap: on any {@code jnt:resource} written under a forge element's
- * {@code icon} or {@code screenshots} folder, it sniffs the actual leading bytes
- * ({@link MagicByteImageValidator}) and, running as system:</p>
+ * <p>The listener is therefore scoped by <b>node structure, not path string</b>: it sniffs any
+ * {@code jnt:resource} whose containing {@code jnt:file} sits under a {@code jmix:forgeElement}
+ * node, and, running as system:</p>
  * <ul>
- *   <li>removes the offending {@code jnt:file} when the bytes are not an allow-listed raster
- *       (SVG/HTML/anything else) — a spoofed non-image never survives; and</li>
- *   <li>corrects {@code jcr:mimeType} to the detected type when the bytes are a valid raster but the
- *       declared mime was spoofed to something else.</li>
+ *   <li><b>Everywhere in the subtree</b> — removes a file that is script-capable (a declared
+ *       SVG/HTML/XML mime, or bytes that sniff as markup), so a planted script file can never be
+ *       served inline. Legitimate binaries (the module JAR/tgz artifact, rasters, …) are untouched
+ *       because they are neither markup nor a script-capable mime.</li>
+ *   <li><b>In the {@code icon}/{@code screenshots} media folders</b> — additionally requires a real
+ *       raster: a non-raster upload is removed and a mismatched declared mime is pinned to the
+ *       detected type.</li>
  * </ul>
  *
- * <p>It follows the module's established {@link DefaultEventListener} pattern (see
+ * <p>Follows the module's established {@link DefaultEventListener} pattern (see
  * {@code ForgeSiteDeletionListener}). Being asynchronous it is defense-in-depth, not the sole gate;
  * the storefront also refuses inline rendering of user files and the client keeps its allow-list.</p>
  */
@@ -66,12 +70,16 @@ public class ForgeMediaMimeListener extends DefaultEventListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ForgeMediaMimeListener.class);
     private static final String MODULES_REPOSITORY = "/contents/modules-repository/";
-    private static final String ICON_SEGMENT = "/icon/";
-    private static final String SCREENSHOTS_SEGMENT = "/screenshots/";
     private static final String JCR_CONTENT = "/jcr:content";
     private static final String PROP_MIME_TYPE = "jcr:mimeType";
     private static final String PROP_DATA = "jcr:data";
     private static final String JNT_RESOURCE = "jnt:resource";
+    private static final String JNT_FILE = "jnt:file";
+    private static final String JMIX_FORGE_ELEMENT = "jmix:forgeElement";
+    private static final String ICON_FOLDER = "icon";
+    private static final String SCREENSHOTS_FOLDER = "screenshots";
+    /** Guard against pathological/looping hierarchies while walking up to the forge element. */
+    private static final int MAX_ANCESTOR_WALK = 32;
     /** Both workspaces are checked: media can be authored in EDIT or directly in LIVE. */
     private static final String[] WORKSPACES = {"default", "live"};
 
@@ -102,7 +110,7 @@ public class ForgeMediaMimeListener extends DefaultEventListener {
         while (events.hasNext()) {
             final Event event = events.nextEvent();
             try {
-                final String resourcePath = forgeMediaResourcePath(event.getPath());
+                final String resourcePath = forgeRepositoryResourcePath(event.getPath());
                 if (resourcePath != null) {
                     validateResource(resourcePath);
                 }
@@ -113,14 +121,12 @@ public class ForgeMediaMimeListener extends DefaultEventListener {
     }
 
     /**
-     * Return the {@code .../jcr:content} node path when {@code eventPath} is (or is a property of) a
-     * jnt:resource under a forge element's {@code icon} or {@code screenshots} folder, else null.
+     * Cheap path pre-filter: return the {@code .../jcr:content} node path when {@code eventPath} is
+     * (or is a property of) a resource under the module repository, else null. The precise, airtight
+     * scoping (is it under a forge element?) is done structurally in {@link #validateInSession}.
      */
-    static String forgeMediaResourcePath(String eventPath) {
+    static String forgeRepositoryResourcePath(String eventPath) {
         if (eventPath == null || !eventPath.contains(MODULES_REPOSITORY)) {
-            return null;
-        }
-        if (!eventPath.contains(ICON_SEGMENT) && !eventPath.contains(SCREENSHOTS_SEGMENT)) {
             return null;
         }
         final int idx = eventPath.indexOf(JCR_CONTENT);
@@ -157,33 +163,77 @@ public class ForgeMediaMimeListener extends DefaultEventListener {
         if (!resource.isNodeType(JNT_RESOURCE) || !resource.hasProperty(PROP_DATA)) {
             return;
         }
+        final JCRNodeWrapper file = resource.getParent();
+        // Structural scope: only files that live under a forge element (module/package) are the
+        // author-writable surface. This replaces the former "/icon//screenshots/" path matching so a
+        // file planted elsewhere in the subtree is covered too (SECURITY-571 #61).
+        if (!file.isNodeType(JNT_FILE) || !isUnderForgeElement(file)) {
+            return;
+        }
         final byte[] header = readHeader(resource);
-        final String detected = MagicByteImageValidator.detectRasterMime(header);
         final String declared = resource.hasProperty(PROP_MIME_TYPE)
                 ? resource.getProperty(PROP_MIME_TYPE).getString() : null;
 
-        if (detected == null) {
-            // Not an allow-listed raster (SVG/HTML/…): remove the containing file so a spoofed,
-            // potentially script-bearing upload cannot be served.
-            final JCRNodeWrapper file = resource.getParent();
-            LOGGER.warn("ForgeMediaMimeListener: removed non-raster upload '{}' (declared mime '{}')",
+        // Rule A (any location under the forge element): a file that could be served inline as
+        // script — a declared SVG/HTML/XML mime, or bytes that sniff as markup — is removed. Legit
+        // binaries (module artifact, rasters) are neither, so they are left untouched.
+        if (MagicByteImageValidator.isScriptCapableMime(declared)
+                || MagicByteImageValidator.looksLikeMarkup(header)) {
+            LOGGER.warn("ForgeMediaMimeListener: removed script-capable upload '{}' (declared mime '{}')",
                     ActionSecurityUtils.sanitizeForLog(file.getPath()),
                     ActionSecurityUtils.sanitizeForLog(declared));
             file.remove();
             session.save();
-        } else if (!detected.equalsIgnoreCase(declared)) {
-            // Valid raster but the declared mime was spoofed: pin it to the sniffed real type.
-            resource.setProperty(PROP_MIME_TYPE, detected);
-            session.save();
-            LOGGER.warn("ForgeMediaMimeListener: corrected spoofed mime on '{}' ('{}' -> '{}')",
-                    ActionSecurityUtils.sanitizeForLog(resourcePath),
-                    ActionSecurityUtils.sanitizeForLog(declared), detected);
+            return;
         }
+
+        // Rule B (media folders only): icons/screenshots must be a genuine raster.
+        if (isMediaFile(file)) {
+            final String detected = MagicByteImageValidator.detectRasterMime(header);
+            if (detected == null) {
+                LOGGER.warn("ForgeMediaMimeListener: removed non-raster media '{}' (declared mime '{}')",
+                        ActionSecurityUtils.sanitizeForLog(file.getPath()),
+                        ActionSecurityUtils.sanitizeForLog(declared));
+                file.remove();
+                session.save();
+            } else if (!detected.equalsIgnoreCase(declared)) {
+                resource.setProperty(PROP_MIME_TYPE, detected);
+                session.save();
+                LOGGER.warn("ForgeMediaMimeListener: corrected spoofed mime on '{}' ('{}' -> '{}')",
+                        ActionSecurityUtils.sanitizeForLog(resourcePath),
+                        ActionSecurityUtils.sanitizeForLog(declared), detected);
+            }
+        }
+    }
+
+    /** True when {@code node} has a {@code jmix:forgeElement} ancestor within the module repository. */
+    private static boolean isUnderForgeElement(JCRNodeWrapper node) throws RepositoryException {
+        JCRNodeWrapper current = node;
+        for (int i = 0; i < MAX_ANCESTOR_WALK && current != null; i++) {
+            if (current.isNodeType(JMIX_FORGE_ELEMENT)) {
+                return true;
+            }
+            if (!current.getPath().contains(MODULES_REPOSITORY)) {
+                return false; // left the module repository without meeting a forge element
+            }
+            try {
+                current = current.getParent();
+            } catch (javax.jcr.ItemNotFoundException rootReached) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    /** True when the file's containing folder is the module's {@code icon} or {@code screenshots}. */
+    private static boolean isMediaFile(JCRNodeWrapper file) throws RepositoryException {
+        final String parentName = file.getParent().getName();
+        return ICON_FOLDER.equals(parentName) || SCREENSHOTS_FOLDER.equals(parentName);
     }
 
     private static byte[] readHeader(JCRNodeWrapper resource) throws RepositoryException {
         try (InputStream in = resource.getProperty(PROP_DATA).getBinary().getStream()) {
-            return in.readNBytes(MagicByteImageValidator.SNIFF_LENGTH);
+            return in.readNBytes(MagicByteImageValidator.MARKUP_SNIFF_LENGTH);
         } catch (IOException e) {
             LOGGER.warn("ForgeMediaMimeListener: could not read '{}' data: {}",
                     ActionSecurityUtils.sanitizeForLog(resource.getPath()), e.getMessage());

--- a/src/main/java/org/jahia/modules/forge/actions/MagicByteImageValidator.java
+++ b/src/main/java/org/jahia/modules/forge/actions/MagicByteImageValidator.java
@@ -25,6 +25,7 @@ package org.jahia.modules.forge.actions;
 
 import java.util.Locale;
 import java.util.Set;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Content-based (magic-byte) detector for the raster image types the store accepts as module
@@ -50,6 +51,21 @@ public final class MagicByteImageValidator {
 
     /** Enough leading bytes to identify every signature below (WEBP needs bytes 8-11 = "WEBP"). */
     public static final int SNIFF_LENGTH = 16;
+
+    /**
+     * Bytes to read for the markup check. Aligns with the ~512-byte window browsers use when
+     * MIME-sniffing, so padding past it also defeats the browser's own sniff (bounded residual).
+     */
+    public static final int MARKUP_SNIFF_LENGTH = 512;
+
+    /**
+     * MIME types a browser will render as script-capable when served inline. A module-owned file
+     * declared as one of these (or whose bytes sniff as markup) must never be served from the site
+     * origin (SECURITY-571 #61). Lower-cased for case-insensitive comparison.
+     */
+    private static final Set<String> SCRIPT_CAPABLE_MIMES = Set.of(
+            "image/svg+xml", "image/svg-xml", "text/html", "application/xhtml+xml",
+            "text/xml", "application/xml");
 
     private MagicByteImageValidator() {
         // utility class - prevent instantiation
@@ -89,6 +105,45 @@ public final class MagicByteImageValidator {
     /** True when {@code mime} is one of the accepted raster types (case-insensitive). */
     public static boolean isAllowedRasterMime(String mime) {
         return mime != null && ALLOWED_RASTER_MIMES.contains(mime.trim().toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * True when {@code mime} names a type a browser renders as script-capable inline (SVG/HTML/XML
+     * family). Any {@code ;charset=...} parameter is ignored and comparison is case-insensitive.
+     */
+    public static boolean isScriptCapableMime(String mime) {
+        if (mime == null) {
+            return false;
+        }
+        final String base = StringUtils.substringBefore(mime, ";").trim().toLowerCase(Locale.ROOT);
+        return SCRIPT_CAPABLE_MIMES.contains(base);
+    }
+
+    /**
+     * True when the leading bytes look like an XML/HTML/SVG document — i.e. the first non-whitespace
+     * byte (after an optional UTF-8 BOM) is {@code '<'}. This catches a file that lies about its
+     * MIME type but whose bytes a browser could sniff and execute as markup (SECURITY-571 #61).
+     */
+    public static boolean looksLikeMarkup(byte[] header) {
+        if (header == null) {
+            return false;
+        }
+        int i = 0;
+        // Skip a UTF-8 BOM (EF BB BF) if present.
+        if (header.length >= 3 && (header[0] & 0xFF) == 0xEF && (header[1] & 0xFF) == 0xBB
+                && (header[2] & 0xFF) == 0xBF) {
+            i = 3;
+        }
+        // Skip ASCII whitespace (space, tab, CR, LF, form-feed, vertical tab).
+        while (i < header.length) {
+            final int b = header[i] & 0xFF;
+            if (b == 0x20 || b == 0x09 || b == 0x0A || b == 0x0D || b == 0x0C || b == 0x0B) {
+                i++;
+            } else {
+                break;
+            }
+        }
+        return i < header.length && (header[i] & 0xFF) == 0x3C; // '<'
     }
 
     private static boolean isWebp(byte[] header) {

--- a/src/test/java/org/jahia/modules/forge/actions/ForgeMediaMimeListenerTest.java
+++ b/src/test/java/org/jahia/modules/forge/actions/ForgeMediaMimeListenerTest.java
@@ -9,9 +9,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Unit tests for the pure event-path matcher of {@link ForgeMediaMimeListener}. The JCR
- * read/reject/correct behaviour needs a running repository (covered by the Cypress E2E); this
- * verifies which events the listener selects and that it normalizes to the resource node path.
+ * Unit tests for the pure event-path pre-filter of {@link ForgeMediaMimeListener}. The precise
+ * scoping (is the file under a jmix:forgeElement?), the media/artifact distinction and the
+ * reject/correct behaviour are node-structure based and need a running repository (covered by the
+ * Cypress E2E). This verifies the cheap path gate that decides which events are loaded at all.
  */
 class ForgeMediaMimeListenerTest {
 
@@ -20,19 +21,30 @@ class ForgeMediaMimeListenerTest {
     @Test
     @DisplayName("matches an icon resource node and its mime/data property events")
     void matchesIconEvents() {
-        assertThat(ForgeMediaMimeListener.forgeMediaResourcePath(BASE + "/icon/logo.png/jcr:content"))
+        assertThat(ForgeMediaMimeListener.forgeRepositoryResourcePath(BASE + "/icon/logo.png/jcr:content"))
                 .isEqualTo(BASE + "/icon/logo.png/jcr:content");
-        assertThat(ForgeMediaMimeListener.forgeMediaResourcePath(BASE + "/icon/logo.png/jcr:content/jcr:mimeType"))
+        assertThat(ForgeMediaMimeListener.forgeRepositoryResourcePath(BASE + "/icon/logo.png/jcr:content/jcr:mimeType"))
                 .isEqualTo(BASE + "/icon/logo.png/jcr:content");
-        assertThat(ForgeMediaMimeListener.forgeMediaResourcePath(BASE + "/icon/logo.png/jcr:content/jcr:data"))
+        assertThat(ForgeMediaMimeListener.forgeRepositoryResourcePath(BASE + "/icon/logo.png/jcr:content/jcr:data"))
                 .isEqualTo(BASE + "/icon/logo.png/jcr:content");
     }
 
     @Test
     @DisplayName("matches a screenshots resource node")
     void matchesScreenshotEvents() {
-        assertThat(ForgeMediaMimeListener.forgeMediaResourcePath(BASE + "/screenshots/shot1.png/jcr:content/jcr:mimeType"))
+        assertThat(ForgeMediaMimeListener.forgeRepositoryResourcePath(BASE + "/screenshots/shot1.png/jcr:content/jcr:mimeType"))
                 .isEqualTo(BASE + "/screenshots/shot1.png/jcr:content");
+    }
+
+    @Test
+    @DisplayName("#61: matches a file planted OUTSIDE icon/screenshots (now covered; structural skip happens later)")
+    void matchesFilePlantedElsewhere() {
+        // Previously returned null (path scoping gap); now the pre-filter admits it and the
+        // structural forge-element check + script-capable rule handle it in-session.
+        assertThat(ForgeMediaMimeListener.forgeRepositoryResourcePath(BASE + "/x.svg/jcr:content"))
+                .isEqualTo(BASE + "/x.svg/jcr:content");
+        assertThat(ForgeMediaMimeListener.forgeRepositoryResourcePath(BASE + "/evil/x.svg/jcr:content/jcr:mimeType"))
+                .isEqualTo(BASE + "/evil/x.svg/jcr:content");
     }
 
     @ParameterizedTest
@@ -40,15 +52,12 @@ class ForgeMediaMimeListenerTest {
     @ValueSource(strings = {
             // Not under modules-repository:
             "/sites/store/home/page.html",
-            // Under modules-repository but not icon/screenshots (e.g. the artifact file itself):
-            "/sites/store/contents/modules-repository/org/acme/mymodule/mymodule-1.0/mymodule-1.0.jar/jcr:content/jcr:mimeType",
-            // icon/screenshots outside the module repository:
             "/sites/store/files/icon/logo.png/jcr:content",
-            // A container node, no jcr:content resource segment:
+            // Under modules-repository but no jcr:content resource segment (a container node):
             "/sites/store/contents/modules-repository/org/acme/mymodule/icon"
     })
-    @DisplayName("ignores events outside forge icon/screenshots resources")
+    @DisplayName("ignores events outside the module repository or with no resource node")
     void ignoresUnrelated(String path) {
-        assertThat(ForgeMediaMimeListener.forgeMediaResourcePath(path)).isNull();
+        assertThat(ForgeMediaMimeListener.forgeRepositoryResourcePath(path)).isNull();
     }
 }

--- a/src/test/java/org/jahia/modules/forge/actions/MagicByteImageValidatorTest.java
+++ b/src/test/java/org/jahia/modules/forge/actions/MagicByteImageValidatorTest.java
@@ -101,4 +101,49 @@ class MagicByteImageValidatorTest {
     void disallowedMimes(String mime) {
         assertThat(MagicByteImageValidator.isAllowedRasterMime(mime)).isFalse();
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "image/svg+xml", "text/html", "application/xhtml+xml", "text/xml", "application/xml",
+            "IMAGE/SVG+XML", "text/html; charset=utf-8", " text/html "})
+    @DisplayName("isScriptCapableMime flags the SVG/HTML/XML family (case- and param-insensitive)")
+    void scriptCapableMimes(String mime) {
+        assertThat(MagicByteImageValidator.isScriptCapableMime(mime)).isTrue();
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"image/png", "image/jpeg", "image/webp", "application/java-archive",
+            "application/gzip", "application/octet-stream", "application/pdf"})
+    @DisplayName("isScriptCapableMime leaves rasters and inert binaries (module artifacts) alone")
+    void nonScriptCapableMimes(String mime) {
+        assertThat(MagicByteImageValidator.isScriptCapableMime(mime)).isFalse();
+    }
+
+    @Test
+    @DisplayName("looksLikeMarkup detects SVG/HTML/XML, including with leading whitespace or a UTF-8 BOM")
+    void detectsMarkup() {
+        assertThat(MagicByteImageValidator.looksLikeMarkup(
+                "<svg xmlns='...'><script>x</script></svg>".getBytes(StandardCharsets.UTF_8))).isTrue();
+        assertThat(MagicByteImageValidator.looksLikeMarkup(
+                "<!doctype html><script>1</script>".getBytes(StandardCharsets.UTF_8))).isTrue();
+        assertThat(MagicByteImageValidator.looksLikeMarkup(
+                "   \n\t <html>".getBytes(StandardCharsets.UTF_8))).isTrue();
+        // UTF-8 BOM (EF BB BF) followed by '<'
+        assertThat(MagicByteImageValidator.looksLikeMarkup(
+                new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF, '<', 's', 'v', 'g'})).isTrue();
+    }
+
+    @Test
+    @DisplayName("looksLikeMarkup returns false for binary/raster/empty content (no false-positive on artifacts)")
+    void ignoresNonMarkup() {
+        // PNG / JPEG / JAR(ZIP 'PK') / gzip magic — none lead with '<'
+        assertThat(MagicByteImageValidator.looksLikeMarkup(withHeader(0x89, 0x50, 0x4E, 0x47))).isFalse();
+        assertThat(MagicByteImageValidator.looksLikeMarkup(withHeader(0xFF, 0xD8, 0xFF))).isFalse();
+        assertThat(MagicByteImageValidator.looksLikeMarkup("PK".getBytes(StandardCharsets.ISO_8859_1))).isFalse();
+        assertThat(MagicByteImageValidator.looksLikeMarkup(withHeader(0x1F, 0x8B))).isFalse();
+        assertThat(MagicByteImageValidator.looksLikeMarkup(new byte[0])).isFalse();
+        assertThat(MagicByteImageValidator.looksLikeMarkup(null)).isFalse();
+        assertThat(MagicByteImageValidator.looksLikeMarkup("plain text".getBytes(StandardCharsets.UTF_8))).isFalse();
+    }
 }


### PR DESCRIPTION
Closes #61 — a residual of #28.

**Problem:** `ForgeMediaMimeListener` gated on the path substrings `/icon/` and `/screenshots/`. A module author holds `OWNER` (jcr:write) across their whole module subtree and writes via the non-CSRF-gated generic `/modules/graphql` mutation, so they could store a spoofed-mime SVG/HTML `jnt:file` **elsewhere** in the subtree, where the listener never sniffed it.

**Fix (remediation #1 — node structure, not path string):**
- Sniff any `jnt:resource` whose `jnt:file` sits under a `jmix:forgeElement` node (mirrors the #54 mixin approach).
- **Everywhere in the subtree:** remove a *script-capable* file — a declared SVG/HTML/XML mime, or bytes that sniff as markup (`looksLikeMarkup`, ~512-byte window matching browser MIME-sniffing).
- **icon/screenshots only:** keep the raster-strict check (non-raster removed, mismatched mime pinned to detected).

**Why legit artifacts are safe:** the module JAR (JAR modules deploy to Maven, not stored as jnt:file) / tgz artifact under a version node is neither markup (leads with `PK`/`0x1F8B`, not `<`) nor a script-capable declared mime, and isn't in a media folder — so it's left untouched. Unit tests assert this (JAR/gzip/raster → not script-capable, not markup).

**Tests:** `mvn clean test` → **144 green** (+18). Behavioural (planted-file removal, artifact-preservation) verified via Docker E2E.

Note: item #2 in the issue (core `FileServlet` `nosniff`/attachment) remains a Jahia-core concern, out of module scope.