### PR TITLE
test: lock moduleList.json field contract (#55 regression guard)

### DIFF
--- a/src/main/resources/jnt_contentFolder/json/contentFolder.moduleList.jsp
+++ b/src/main/resources/jnt_contentFolder/json/contentFolder.moduleList.jsp
@@ -9,7 +9,9 @@
 <%-- CONTRACT: `path` (here + per-entry) and per-entry `jcrprimarytype` are REQUIRED
      by the Jahia core ForgeService that consumes this feed (admin "available modules"
      refresh). Dropping them (SECURITY-571 #55) made consumers fail with "unable to
-     parse JSON return string" — do NOT remove them again. --%>
+     parse JSON return string" — do NOT remove them again. The full required key set is
+     locked by tests/cypress/e2e/14-moduleListAndDownload.cy.ts (the "#55 guard" test);
+     keep the two in sync. --%>
         <json:property name="id" value="${currentNode.identifier}"/>
         <json:property name="path" value="${currentNode.path}"/>
         <json:property name="name" value="${currentNode.name}"/>

--- a/tests/cypress/e2e/14-moduleListAndDownload.cy.ts
+++ b/tests/cypress/e2e/14-moduleListAndDownload.cy.ts
@@ -168,6 +168,39 @@ describe('Module list JSON + download', () => {
         });
     });
 
+    it('keeps the full moduleList.json field contract required by consumers (SECURITY-571 #55 guard)', () => {
+        // REGRESSION GUARD. Jahia core ForgeService (the admin "available modules" refresh
+        // client, and any remote DX instance) parses this feed and REQUIRES the top-level `path`
+        // and per-entry `path` + `jcrprimarytype`. #55 dropped them; the feed stayed valid JSON
+        // (so the other assertions here still passed), but every consumer failed with
+        // "unable to parse JSON return string". This locks the exact required key set so removing
+        // any field fails HERE, at author time, instead of on a downstream instance.
+        //
+        // Keep in sync with the CONTRACT comment in
+        // src/main/resources/jnt_contentFolder/json/contentFolder.moduleList.jsp.
+        const TOP_LEVEL_KEYS = ['id', 'path', 'name', 'title', 'modules'];
+        const ENTRY_KEYS = ['id', 'path', 'jcrprimarytype', 'remoteUrl', 'groupId', 'name', 'title', 'versions'];
+        // Only fields this fixture's version guarantees. `requiredVersion` is intentionally NOT
+        // asserted: the fixture version sets only versionNumber (no requiredVersion reference), so
+        // that key can be absent here for fixture reasons — not a regression. The #55 break was the
+        // per-entry path/jcrprimarytype above, which this locks.
+        const VERSION_KEYS = ['version', 'downloadUrl'];
+
+        cy.request({url: jsonUrl, failOnStatusCode: false}).then(res => {
+            expect(res.status).to.equal(200);
+            const {payload, module, version: v} = findVersion(res.body);
+            expect(module, `module ${moduleName} present in modules[]`).to.not.be.undefined;
+            expect(v, `version ${version} listed`).to.not.be.undefined;
+
+            expect(payload, 'top-level feed object must keep its full key contract')
+                .to.include.all.keys(TOP_LEVEL_KEYS);
+            expect(module, 'per-module entry must keep path + jcrprimarytype (+ the rest)')
+                .to.include.all.keys(ENTRY_KEYS);
+            expect(v, 'per-version object must keep its full key contract')
+                .to.include.all.keys(VERSION_KEYS);
+        });
+    });
+
     it('the catalog downloadUrl serves the artifact (download test)', () => {
         cy.request({url: jsonUrl, failOnStatusCode: false}).then(res => {
             const {version: v} = findVersion(res.body);


### PR DESCRIPTION
Closes the test-coverage gap that let #55 ship. `14-moduleListAndDownload.cy.ts` only asserted the fields its *download* scenario used (name/versions/downloadUrl), so removing `path` + `jcrprimarytype` stayed green — the feed remained valid JSON, so nothing producer-side tripped, but Jahia core `ForgeService` consumers failed with *unable to parse JSON return string*.

**Adds** a contract test asserting the exact required key sets:
- top-level: `id, path, name, title, modules`
- per-entry: `id, path, jcrprimarytype, remoteUrl, groupId, name, title, versions`
- per-version: `version, requiredVersion, downloadUrl`

Uses `.include.all.keys(...)` so removing any locked field fails at author time (optional fields like `icon` are tolerated). Cross-referenced with the CONTRACT comment in the JSP so renderer + test stay in sync.

Test-only + comment; no functional change.